### PR TITLE
Handle missing topology gracefully for IP routing tests

### DIFF
--- a/spytest/tests/routing/test_ip.py
+++ b/spytest/tests/routing/test_ip.py
@@ -77,7 +77,7 @@ def ip_module_hooks(request):
         topo_requirements.extend(["D1T1:2", "D2T1:2"])
 
     try:
-        vars = st.ensure_min_topology(*topo_requirements)
+        vars = st.ensure_min_topology(*topo_requirements, fail=False)
     except Exception as exc:  # pylint: disable=broad-except
         pytest.skip("Required DUT topology is not available: {}".format(exc))
     if not vars:
@@ -88,7 +88,7 @@ def ip_module_hooks(request):
     if missing:
         pytest.skip("Missing required DUT links: {}".format(", ".join(missing)))
 
-    vars = st.ensure_min_topology(*topo_requirements)
+    vars = st.ensure_min_topology(*topo_requirements, fail=False)
     if not vars:
         pytest.skip("Required DUT topology is not available")
 


### PR DESCRIPTION
## Summary
- call `st.ensure_min_topology` with `fail=False` in the IP routing module fixture so missing resources result in a skip instead of a topology failure report

## Testing
- `pytest spytest/tests/routing/test_ip.py -k test_l3_v4_route_po_1 -vv` *(fails: ModuleNotFoundError: No module named 'spytest')*

------
https://chatgpt.com/codex/tasks/task_e_68c8486daffc8328a78a8f27c5abec62