### PR TITLE
Add NAT TCP test case QA analysis doc

### DIFF
--- a/docs/test_nat_tcp_analysis.md
+++ b/docs/test_nat_tcp_analysis.md
@@ -1,0 +1,41 @@
+# NAT TCP SpyTest Case Review
+
+## 1. Topology Type Used
+- **Topology:** Linear three-device setup (D1-D2-D3) with one link between D1/D2 and one between D2/D3.
+- **Inference:** The module setup calls `st.ensure_min_topology("D1D2:1", "D2D3:1")`, which requests exactly one connection between devices D1-D2 and D2-D3, indicating a chained three-DUT topology for the viewer. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L51-L77】
+
+## 2. Overall Test Case Purpose
+- Validate that a dynamic NAPT configuration correctly creates translation entries for a traceroute originating from D3 toward D1, ensuring NAT handles UDP traceroute traffic and populates expected translation table entries on the middle DUT (D2). 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L80-L114】
+
+## 3. Subtestcases and Contributions
+1. **Module Autouse Fixture `nat_module_config`:** Executes `nat_pre_config` before any tests and `nat_post_config` afterward to provision and clean up the NAT environment. This guarantees that the NAT feature, zones, pools, and static routes are present before the traceroute validation runs and that the DUT is restored afterward. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L37-L123】
+2. **`nat_pre_config` Setup Routine:**
+   - Ensures the required D1-D2-D3 topology, verifies platform support, and configures interface IPs, static routes, NAT feature state, zone bindings, and pool/binding objects on D2.
+   - Without these steps, traceroute traffic would not traverse a configured NAT path, so the main verification would fail or be meaningless. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L51-L77】
+3. **Test Method `test_ft_dynamic_napt_traceroute`:**
+   - Clears existing translations/statistics, triggers traceroute traffic from D3 to D1, and checks that UDP translation entries appear for three expected destination ports.
+   - Each translation check confirms that traceroute’s multi-probe UDP packets are translated through the configured NAT, directly validating the test’s objective. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L80-L114】
+4. **`nat_post_config` Teardown Routine:**
+   - Removes zone assignments, clears NAT configuration, disables the feature, deletes static routes, and clears IP configuration, ensuring no residual setup impacts other tests. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L116-L123】
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:** Module-scoped `nat_module_config` (autouse) and function-scoped `cmds_func_hooks` placeholder. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L37-L50】
+- **Topology Constraints:** Requires a three-DUT chain with interfaces D1D2P1 and D2D3P1 on the central device, supplied by `st.ensure_min_topology`. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L51-L77】
+- **Platform Support:** Skips platforms listed in datastore constant `TH3_PLATFORMS`, fetched via `st.get_datastore`. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L54-L58】
+- **NAT Feature Availability:** NAT capability must be enabled on D2, and the environment must support NAT configuration APIs. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L68-L75】
+
+## 5. Key Inputs and Sources
+- **Hardcoded Test Parameters:** IP addresses, prefixes, zone IDs, protocol names, pool/binding names, and port ranges are defined in the local `data` dictionary at the top of the file. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L14-L35】
+- **Topology-Derived Variables:** Device names, interface identifiers, and other connection metadata come from `st.ensure_min_topology`, which consumes the active testbed definition (`testbed.yaml`). 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L51-L77】
+- **Datastore Constants:** Platform capability list (`TH3_PLATFORMS`) retrieved by `st.get_datastore`, typically populated from group variables or SpyTest datastore defaults. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L54-L58】
+- **Runtime Traffic Checks:** Translation queries use the UDP protocol flag and destination ports from the predefined `data` list, confirming entries returned by the NAT API. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L88-L114】
+- **CLI Parameters:** Not specified.
+
+## 6. External Libraries and Roles
+- **`pytest`:** Provides the fixture and test function structure. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L1-L50】
+- **`spytest.st`:** Offers topology utilities, logging, reporting, datastore access, and testbed variable retrieval. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L51-L124】
+- **`spytest.dicts.SpyTestDict`:** Supplies the structured `data` dictionary for test parameters. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L14-L35】
+- **`utilities.common`:** Used for the `exec_all` helper to run route-show commands concurrently. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L6-L77】
+- **`apis.routing.ip`:** Handles interface IP configuration, static routes, ping/traceroute operations, and cleanup. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L8-L123】
+- **`apis.routing.nat`:** Manages NAT feature enablement, zone configuration, pools, bindings, translation queries, and cleanup. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L68-L135】
+- **`apis.system.basic`:** Retrieves hardware SKU for platform capability checks. 【F:spytest/tests/routing/NAT/test_nat_tcp.py†L54-L58】


### PR DESCRIPTION
## Summary
- add a markdown report that captures topology, objectives, subtests, dependencies, inputs, and libraries for `test_nat_tcp`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd3173eb0c832896c66b246cdca954