### PR TITLE
Add QA analysis for routing IP spytest suite

### DIFF
--- a/spytest/tests/routing/test_ip_analysis.md
+++ b/spytest/tests/routing/test_ip_analysis.md
@@ -1,0 +1,31 @@
+# Test Case Analysis: `spytest/tests/routing/test_ip.py`
+
+## 1. Topology Type and Inference
+- The module fixture `ip_module_hooks` requests `st.ensure_min_topology("D1T1:2", "D2T1:2", "D1D2:4")`, implying the topology viewer should present two DUTs (D1 and D2) with two traffic-generator links each and four inter-DUT connections available for routing tests. The inference comes from the SpyTest naming convention (`D1T1`, `D2T1`, `D1D2`) that maps DUT-to-TG and DUT-to-DUT links.
+
+## 2. Overall Test Purpose
+- This module exercises IPv4 and IPv6 routing behavior across VLAN interfaces, port-channels, and routed physical links. It validates large-scale BGP route programming, static route forwarding (including blackhole handling), reachability after IP reconfiguration, L2↔L3 mode transitions, and reporting/ordering features such as RIF counter updates and `show ip/ipv6 interface` output consistency.
+
+## 3. Subtestcases and Rationale
+- **`test_l3_v4_route_po_1`** – Calls `create_v4_route` to establish a BGP session with the traffic generator, advertise 30k IPv4 routes, and confirm traffic forwarding over the port-channel path. This verifies control-plane scaling and data-plane delivery needed before other routing scenarios are attempted.
+- **`test_ft_ping_v4_v6_vlan`** – Performs IPv4 and IPv6 pings between the DUTs over the routed VLAN interface to ensure baseline dual-stack connectivity prior to more complex workflows.
+- **`test_ft_ping_v4_v6_after_ip_change_pc`** – Brings the port-channel up, validates dual-stack pings, removes/reapplies new IPv4/IPv6 addresses (plus a temporary static NDP entry), and revalidates reachability, proving that interface reconfiguration does not break routing.
+- **`test_ft_ip6_static_route_traffic_forward_blackhole`** – Sends IPv6 traffic via a configured static route, gathers RIF counters, then replaces the next hop with a blackhole entry to confirm that traffic stops and counters reflect the change, covering both forwarding and drop behavior.
+- **`test_ft_ip_static_route_traffic_forward`** – Mirrors the IPv6 test for IPv4 traffic, including counter validation across a link flap and repeated traffic runs to ensure static routes and RIF counters behave correctly.
+- **`test_ft_ip_v4_v6_L2_L3_translation`** – Switches interfaces between routed and VLAN modes, exercises VLAN-tagged traffic via the traffic generator, then restores L3 routing and verifies dual-stack reachability, ensuring the platform handles port role transitions without residual config.
+- **`test_ft_verify_interfaces_order`** – Randomly selects free interfaces, programs alternating IPv4/IPv6 addresses, and checks that `show ip interface` and `show ipv6 interface` list entries in sorted order, protecting the CLI presentation layer.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures**: `ip_module_hooks` performs all base configuration and cleanup (VLANs, port-channels, routed links, static routes); `ip_func_hooks` is an autouse placeholder for per-test hooks; `ft_verify_interfaces_order_hooks` rolls back interface IP assignments for the ordering test; `ceta_31902_fixture` provisions additional VLAN/static-route state but is not referenced elsewhere in this file.
+- **Platform requirements**: `rif_support_check` uses the detected HWSKU to determine if RIF counters are supported and drives conditional expectations in the static-route tests. Traffic-generator connectivity (`tgapi.get_handles_byname`) must exist for the named ports. Other hardware or topology constraints beyond `ensure_min_topology` are not specified.
+
+## 5. Key Inputs and Their Sources
+- The shared `data` dictionary seeds IPv4/IPv6 subnets, BGP ASNs, VLAN IDs (randomized via `random_vlan_list()`), MAC addresses, static routes, traffic rates, and helper masks used across tests. Random sampling also chooses free interfaces for the ordering check.
+- `vars` from `st.ensure_min_topology` supplies DUT identifiers and physical port aliases (`D1T1P1`, `D2D1P4`, etc.) that match entries in the SpyTest testbed definition (exact mappings are not specified here).
+- BGP and traffic-generator configuration dictionaries (`conf_var`, `route_var`, `bgp_conf`) are built inside the helper functions to drive route scale scenarios. Normalized packet rates and host counts come from `tgapi.normalize_pps` and `tgapi.normalize_hosts`.
+
+## 6. External Libraries and Roles
+- `pytest` powers fixtures/marks; the SpyTest framework (`st`, `tgapi`, `SpyTestDict`) supplies logging, topology discovery, and traffic-generator control.
+- `apis.routing.ip`, `apis.switching.vlan`, `apis.switching.portchannel`, `apis.system.basic`, `apis.common.asic`, `apis.routing.bgp`, `apis.system.interface`, `apis.routing.route_map`, and `apis.routing.arp` provide SONiC control-plane helpers for interface IP management, L2 membership, port-channel operations, hardware queries, route programming, interface counters, route-map creation, and neighbor manipulations.
+- Utility modules (`utilities.common.random_vlan_list`, `utilities.utils.rif_support_check`, `utilities.utils.report_tc_fail`) and Python stdlib modules (`random`, `math`, `re`) assist with dynamic data selection, capability gating, failure reporting, and address/integer parsing.
+


### PR DESCRIPTION
## Summary
- add a QA-focused analysis for `spytest/tests/routing/test_ip.py`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd36fde4ec8328889e34f070c2d9fc