### PR TITLE
Add QA summary for portchannel spytest case

### DIFF
--- a/spytest/tests/switching/test_portchannel_analysis.md
+++ b/spytest/tests/switching/test_portchannel_analysis.md
@@ -1,0 +1,39 @@
+# SpyTest Test Case Review: `test_portchannel.py`
+
+## 1. Topology
+- **Topology requirement**: The module-level fixture calls `st.ensure_min_topology("D1D2:4", "D1T1:1", "D2T1:1")`, which implies a topology with two DUTs interconnected by four links and each DUT connected to a traffic generator port (T1P1).【F:spytest/tests/switching/test_portchannel.py†L37-L59】
+- **Inference**: `ensure_min_topology` supplies handles such as `vars.D1D2P1` and `vars.D1T1P1` that are later used to build the LAG members and traffic generator configuration, confirming the test assumes a dual-DUT with traffic generator topology.【F:spytest/tests/switching/test_portchannel.py†L52-L90】
+
+## 2. Overall Purpose
+- Validate SONiC port-channel (LAG) functionality across L2/L3 forwarding, VLAN membership ordering, LLDP, member churn, graceful restart, and hashing behavior under tagged and untagged traffic conditions using a traffic generator.【F:spytest/tests/switching/test_portchannel.py†L378-L599】【F:spytest/tests/switching/test_portchannel.py†L606-L939】
+
+## 3. Subtests
+1. **`test_ft_portchannel_behavior_with_tagged_traffic`** – Exercises twelve tagged-traffic scenarios including deletion protection, member removal/re-addition, hashing redistribution, LLDP checks, admin shutdown handling, VLAN membership gating, single-member operation, partner absence detection, and member-state transitions, ensuring end-to-end L2 correctness under various operational events.【F:spytest/tests/switching/test_portchannel.py†L378-L599】
+2. **`test_ft_untagged_traffic_on_portchannel`** – Sends untagged traffic to confirm LAGs treat untagged frames like regular ports, protecting regression of default VLAN forwarding.【F:spytest/tests/switching/test_portchannel.py†L606-L617】
+3. **`test_ft_lag_l3_hash_sip_dip_l4port`** – Configures IP addresses/routes and varied L3/L4 flows to validate hashing, ARP aging after shutdown, static routing, and traffic-loss checks for routed port-channels.【F:spytest/tests/switching/test_portchannel.py†L618-L699】
+4. **`test_ft_member_state_after_interchanged_the_members_across_portchannels`** – Builds a second LAG, swaps members, and verifies states go down/up appropriately, ensuring LACP reacts correctly to asymmetric member changes across port-channels.【F:spytest/tests/switching/test_portchannel.py†L700-L845】
+5. **`test_ft_portchannel_with_vlan_variations`** – Validates LAG state when VLAN association happens before versus after enabling the LAG, covering configuration-order sensitivities.【F:spytest/tests/switching/test_portchannel.py†L847-L886】
+6. **`test_ft_lacp_graceful_restart_with_cold_boot`** – Exercises teamd graceful restart handling through a cold reboot, checking LAG status transitions and syslog markers.【F:spytest/tests/switching/test_portchannel.py†L889-L913】
+7. **`test_ft_lacp_graceful_restart_with_save_reload`** – Similar to above but using config save & reload, ensuring persistence flows retain graceful restart behavior.【F:spytest/tests/switching/test_portchannel.py†L916-L939】
+
+## 4. Dependencies & Prerequisites
+- **Fixtures**: Module-level `portchannel_module_hooks` provisions topology, VLANs, and traffic generator configuration; function-level `portchannel_func_hooks` performs per-test setup/cleanup tailored to each test.【F:spytest/tests/switching/test_portchannel.py†L26-L137】
+- **Utilities**: Extensive use of `exec_all`, `exec_parallel`, and `ensure_no_exception` for parallel operations across DUTs.【F:spytest/tests/switching/test_portchannel.py†L18-L20】【F:spytest/tests/switching/test_portchannel.py†L139-L158】【F:spytest/tests/switching/test_portchannel.py†L235-L316】
+- **Traffic generator**: Requires TG handles via `tgapi.get_handle_byname` and configured streams, indicating dependency on an external traffic generator setup in the testbed.【F:spytest/tests/switching/test_portchannel.py†L63-L77】【F:spytest/tests/switching/test_portchannel.py†L395-L399】【F:spytest/tests/switching/test_portchannel.py†L608-L616】
+- **Topology constraints**: Relies on four D1↔D2 member links and TG connectivity; removal/addition sequences assume at least four members available.【F:spytest/tests/switching/test_portchannel.py†L37-L59】【F:spytest/tests/switching/test_portchannel.py†L407-L575】
+- **Prerequisite configs**: Additional helper routines (e.g., `graceful_restart_prolog`) create secondary port-channels when graceful restart tests run.【F:spytest/tests/switching/test_portchannel.py†L139-L151】【F:spytest/tests/switching/test_portchannel.py†L889-L939】
+
+## 5. Key Inputs
+- **Port-channel & VLAN IDs**: `PortChannel7/8` hardcoded; VLAN IDs randomly chosen via `random_vlan_list(count=2)` ensuring non-conflicting VLANs per execution.【F:spytest/tests/switching/test_portchannel.py†L31-L36】
+- **Topology handles**: `vars.D1`, `vars.D2`, interconnect ports, and TG ports derived from `ensure_min_topology`, meaning they originate from the `testbed.yaml` topology definition used by SpyTest.【F:spytest/tests/switching/test_portchannel.py†L37-L58】
+- **IP addressing & traffic parameters**: Static values assigned in the fixture for TG interfaces and routing scenarios (e.g., `data.ip41`, `data.ip_addr_pc1`, TCP port counts).【F:spytest/tests/switching/test_portchannel.py†L40-L50】【F:spytest/tests/switching/test_portchannel.py†L618-L682】
+- **CLI/REST choices**: `data.cli_type_click` is preset, but no command-line parameterization is evident—treated as internal default.【F:spytest/tests/switching/test_portchannel.py†L36-L37】
+- **External configuration files**: No explicit references to `group_vars` or other inventory files beyond the topology handles; if present, they are not specified. *Not specified*.
+
+## 6. External Libraries & Roles
+- **`pytest`** – Provides fixture and test-case structure.【F:spytest/tests/switching/test_portchannel.py†L1-L27】
+- **SpyTest core (`st`, `tgapi`, `SpyTestDict`)** – Offers logging, topology discovery, traffic generator interaction, and shared data storage.【F:spytest/tests/switching/test_portchannel.py†L4-L77】
+- **SONiC API wrappers**: `apis.switching.portchannel`, `apis.switching.vlan`, `apis.system.interface`, `apis.routing.ip`, `apis.routing.arp`, `apis.system.port`, `apis.system.rest`, `apis.system.logging`, `apis.system.basic`, `apis.system.lldp` – Used to configure and verify SONiC features such as LAGs, VLANs, interfaces, routing, ARP, REST validation, logging, device basics, and LLDP.【F:spytest/tests/switching/test_portchannel.py†L6-L16】【F:spytest/tests/switching/test_portchannel.py†L139-L939】
+- **Utility helpers (`utilities.parallel`, `utilities.common`)** – Enable concurrent execution, random VLAN selection, and polling mechanisms for status verification.【F:spytest/tests/switching/test_portchannel.py†L18-L20】【F:spytest/tests/switching/test_portchannel.py†L235-L375】
+- **Python standard library**: `random.randrange` used for random member selection in hashing tests.【F:spytest/tests/switching/test_portchannel.py†L2-L413】
+


### PR DESCRIPTION
## Summary
- add a markdown review of spytest/tests/switching/test_portchannel.py covering topology, purpose, and subtests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0d42b18e48328a26368ea4bda2da9