### PR TITLE
Add analysis for box services uptime test

### DIFF
--- a/spytest/tests/system/test_box_services_analysis.md
+++ b/spytest/tests/system/test_box_services_analysis.md
@@ -1,0 +1,31 @@
+# Test Case Analysis: `test_box_services.py`
+
+## 1. Topology Type Used
+- **Topology:** Single DUT (`D1`).
+- **Inference:** The module-level autouse fixture calls `st.ensure_min_topology("D1")`, explicitly requiring one device labeled `D1` before tests execute.【F:spytest/tests/system/test_box_services.py†L6-L10】
+
+## 2. Overall Test Case Purpose
+- Validates that the `show uptime` command (queried through `boxserv_obj.get_system_uptime_in_seconds`) advances monotonically over a one-minute interval, confirming correct system uptime reporting.【F:spytest/tests/system/test_box_services.py†L18-L39】
+
+## 3. Subtestcases and Their Roles
+- **`test_ft_system_uptime`**
+  - Captures the initial uptime in seconds from device `D1`. Establishes the baseline for comparison.【F:spytest/tests/system/test_box_services.py†L23-L28】
+  - Waits 60 seconds to allow uptime to increment. Provides the time window necessary to observe change.【F:spytest/tests/system/test_box_services.py†L27-L30】
+  - Retrieves the uptime again and asserts it falls within the expected range (`initial + 60` to `initial + 120`). Confirms that uptime increases as expected and that the command returns realistic values.【F:spytest/tests/system/test_box_services.py†L30-L39】
+
+## 4. Dependencies / Prerequisites
+- **Fixtures:**
+  - Module-level autouse fixture `box_service_module_hooks` ensures topology availability via `st.ensure_min_topology("D1")`.【F:spytest/tests/system/test_box_services.py†L6-L11】
+  - Function-level autouse fixture `box_service_func_hooks` (no additional logic).【F:spytest/tests/system/test_box_services.py†L12-L15】
+- **Libraries / Framework:** Relies on `pytest` for fixture management and marking.【F:spytest/tests/system/test_box_services.py†L1-L2】
+- **Topology Constraints:** Requires at least one SONiC device (`D1`) accessible through SpyTest APIs.
+
+## 5. Key Inputs
+- `vars = st.get_testbed_vars()`: Retrieves testbed-specific variables, including device handles, from SpyTest configuration (e.g., `testbed.yaml`).【F:spytest/tests/system/test_box_services.py†L22-L24】
+- `vars.D1`: Device handle for the DUT, derived from the loaded testbed definition.【F:spytest/tests/system/test_box_services.py†L24-L39】
+- Static wait duration (`60` seconds) defined inline within the test.【F:spytest/tests/system/test_box_services.py†L27-L30】
+
+## 6. External Libraries and Roles
+- `pytest`: Testing framework providing fixtures, test discovery, and markers.【F:spytest/tests/system/test_box_services.py†L1-L2】
+- `spytest.st`: SpyTest service layer offering topology management, logging, waiting, and reporting utilities used throughout the test.【F:spytest/tests/system/test_box_services.py†L2-L38】
+- `apis.system.box_services`: Supplies `get_system_uptime_in_seconds` to query device uptime via SONiC CLI or API abstractions.【F:spytest/tests/system/test_box_services.py†L3-L33】


### PR DESCRIPTION
## Summary
- add a detailed markdown analysis of the `test_box_services.py` SpyTest case

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0ea562bf083288aec79b5f9978397