### PR TITLE
Add analyzer for BGP 4-node SpyTest suite

### DIFF
--- a/docs/spytest_doc/routing/BGP/test_bgp_4node_analyzer.md
+++ b/docs/spytest_doc/routing/BGP/test_bgp_4node_analyzer.md
@@ -1,0 +1,63 @@
+# Test Case Analyzer: `spytest/tests/routing/BGP/test_bgp_4node.py`
+
+## 1. Topology type
+- **Topology**: Four-node BGP confederation topology with SONiC devices D1–D4 interconnected through multiple point-to-point links that enable both eBGP and iBGP relationships.
+- **Inference**:
+  - The module setup enforces `st.ensure_min_topology('D1D2:1', 'D2D3:1', 'D2D4:1', 'D3D4:1', 'D3D1:1')`, proving that five distinct physical or sub-interface links between the four DUTs are required before tests start.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L49-L53】
+  - `bgp4nodelib.get_confed_topology_info()` populates a shared `topo` map that enumerates the DUT list, their ASNs, and neighbor addressing for the confederation scenario, confirming the testbed is a confederated four-node design.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L59-L62】
+  - Several tests call `st.get_testbed_vars()` to fetch interface names such as `D1D3P1` that exist only when all four nodes are cabled, reinforcing that the topology is the SpyTest four-node routed fabric defined in the testbed YAML.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L332-L339】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L407-L414】
+
+## 2. Overall test case purpose
+- **High-level goal**: Validate BGP functionality, resiliency, and policy handling across a four-node SONiC deployment that mixes confederation, iBGP route-reflection, and eBGP community manipulation for both IPv4 and IPv6 routes.
+- **Context within SONiC/SpyTest**: The suite uses SpyTest BGP and IP helper APIs to configure routing sessions, advertise prefixes, apply route-maps, and inspect the control-plane tables. It ensures that SONiC’s FRR-based BGP stack behaves correctly when operating in confederated topologies, enforces route-map policies, and handles BGP communities across multi-router fabrics.
+
+## 3. Detailed breakdown of sub-testcases
+
+### Shared fixtures and helpers
+- `bgp_module_hooks` (module-scope, autouse) invokes `bgp_pre_config` to provision IPv4/IPv6 addressing (optionally on sub-interfaces) across the DUT mesh, verifies basic reachability with ping, and tears down the addresses in `bgp_pre_config_cleanup` after all tests.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L41-L86】 This guarantees the baseline routed fabric is ready for every test.
+- `bgp_confed_class_hook` (class-scope) calls `bgp_confed_pre_config` / cleanup to enable confederation BGP neighbors prior to class-level tests, ensuring the confederation underlay exists before individual validations run.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L101-L126】
+- `hooks_test_ft_bgp_ibgp_RR_Loop` and `hooks_test_ft_bgp_ebgp_community_map` (function-scope) remove BGP sessions, interface IPs, and policy artifacts created by their respective tests, preventing configuration bleed-over between cases.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L319-L330】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L517-L534】
+
+### `TestBGPConfed.test_ipv6_confed_route_distribution`
+- **Intent & logic**: Advertises IPv4 (`131.5.6.0/24`) and IPv6 (`2000:1::/64`) networks from DUT1 within its confederation AS and confirms the routes appear on confederation peer DUT3 using `bgpapi.get_ip_bgp_route`. It cleans up by withdrawing the networks.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L131-L172】
+- **Why it matters**: Proves that confederation members properly redistribute routes across sub-AS boundaries for both address families, establishing a baseline for the remaining policy tests.
+
+### `TestBGPConfed.test_ipv6_confed_with_rr`
+- **Intent & logic**: Starts with an IPv4/IPv6 advertisement from DUT2 and verifies DUT4 does **not** learn it until DUT3 is configured as a route-reflector client for both families; afterwards it expects the routes on DUT4, then removes the advertisements and RR settings.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L174-L227】
+- **Why it matters**: Validates confederation-aware route-reflector behavior, ensuring routes propagate only when reflection is configured—critical for hierarchical BGP designs.
+
+### `TestBGPConfed.test_confed_route_distribution_with_rmap`
+- **Intent & logic**: Builds access-lists and a route-map on DUT1 to prepend AS-paths, deny, or permit specific prefixes before advertising them. On DUT2 it checks for AS-path prepending, verifies denied prefixes are absent, and confirms permitted ones are installed; it then dismantles the policy and advertisements.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L229-L303】
+- **Why it matters**: Demonstrates that confederation peers honor route-map policies, verifying policy enforcement and filtering within the BGP control-plane.
+
+### `test_ft_bgp_ibgp_RR_Loop`
+- **Intent & logic**: Creates additional IPv4 interfaces between DUT1 and DUT3, establishes full-mesh iBGP sessions among DUT1–D3 using the same AS, and configures mutual route-reflector client relationships. It checks session establishment, advertises a loopback route from DUT3, ensures DUT1 and DUT2 learn it, and confirms the origin retains next-hop `0.0.0.0` to detect reflector loops before cleaning up via the fixture.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L305-L366】
+- **Why it matters**: Ensures iBGP route-reflector clusters avoid routing loops and propagate routes correctly inside the confederation fabric.
+
+### `test_ft_bgp_ebgp_community_map`
+- **Intent & logic**: After adding IPv4 connectivity between DUT1 and DUT3, the test forms IPv4 and IPv6 eBGP sessions across all four nodes, advertises routes, and applies route-maps that set, delete subsets of, or clear community attributes. It validates outbound and inbound community manipulation for IPv4 and IPv6, leverages a community list (`comm_test`), and checks redistributing connected routes with community tagging before tearing down all policy and neighbor state.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L372-L516】
+- **Why it matters**: Confirms SONiC can add, modify, and strip BGP community attributes through route-maps in both address families—key for traffic engineering and policy control.
+
+## 4. Dependencies and prerequisites
+- Relies on SpyTest fixtures (`bgp_module_hooks`, `bgp_confed_class_hook`, function-level cleanup hooks) to stage and reset network state, meaning the pytest environment must honor these fixtures.
+- Requires the SpyTest BGP/IP helper libraries (`apis.routing.bgp`, `apis.routing.ip`, `BGP.bgp4nodelib`) to be available so that configuration and validation commands can be issued to the DUTs.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L7-L12】
+- Expects a four-DUT lab with connectivity matching the enforced topology strings and optional sub-interface support when the `routed_sub_intf` runtime argument is set.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L41-L72】
+- Depends on FRR/SONiC features such as BGP confederation, route reflection, route-maps, access-lists, and community lists being enabled on the devices.
+
+## 5. Key inputs and parameters
+- `bgp_4node_data`: Central dataset storing ASNs, network prefixes, loopback names, wait timers, and helper IPs used across tests. These values drive BGP session formation, route advertisements, and policy checks.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L14-L38】
+- `sub_intf = st.get_args("routed_sub_intf")`: Determines whether addressing is configured on physical interfaces or sub-interfaces during module setup, providing flexibility for different lab wiring models.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L41-L55】
+- `topo`: Populated by `bgp4nodelib.get_confed_topology_info()` and extended with `st.get_testbed_vars()`, it supplies DUT identifiers, AS numbers, interface names, and neighbor addresses for subsequent API calls.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L59-L62】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L332-L356】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L407-L435】
+- Test-specific constants such as `network_ipv4`, `network_ipv6`, `access_list1/2/3`, `as_path`, and `test_case_id` are defined inline to direct each scenario’s advertisements and policy verification.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L139-L166】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L178-L221】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L233-L261】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L381-L426】
+
+## 6. External libraries and modules
+- `pytest`: Provides the fixture system, markers, and test discovery used throughout the module.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L3】
+- `spytest.st` & `SpyTestDict`: SpyTest service layer for logging, topology utilities (`banner`, `poll_wait`, `report_fail/pass`), argument retrieval, and shared data structures.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L5-L6】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L41-L85】
+- `apis.routing.bgp` (`bgpapi`): Wrapper around SONiC BGP configuration/show commands used to form neighbors, advertise routes, manage route-reflector clients, check route tables, and manipulate community lists.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L7-L8】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L131-L520】
+- `apis.routing.ip` (`ipapi`): Manages IP addressing, access-lists, and route-maps that complement the BGP scenarios.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L8-L9】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L233-L520】
+- `BGP.bgp4nodelib`: Custom SpyTest library encapsulating the standard four-node configuration routines (IP setup, BGP confederation configuration, ping, topology discovery).【F:spytest/tests/routing/BGP/test_bgp_4node.py†L9-L10】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L49-L124】
+- `utilities.common.ExecAllFunc`: Helper used with `st.exec_all`/`st.exec_each2` to run multiple API calls in parallel for efficiency.【F:spytest/tests/routing/BGP/test_bgp_4node.py†L11】【F:spytest/tests/routing/BGP/test_bgp_4node.py†L340-L403】
+
+## 7. Unspecified items
+- The exact contents of `testbed.yaml`, traffic generator details, and hardware/ASIC models for the DUTs are not specified in the test file.
+- Credentials, management addressing, and any external dependencies (e.g., route servers or monitoring tools) are not provided.


### PR DESCRIPTION
## Summary
- add SpyTest QA analyzer for the four-node BGP regression tests
- document topology, fixtures, dependencies, and policy coverage for the confederation and community scenarios

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d3176d2560833397e55bc5085e2df8