### PR TITLE
Add analyzer documentation for ARP SpyTest

### DIFF
--- a/docs/spytest_doc/spytest/tests/routing/test_arp_analyzer.md
+++ b/docs/spytest_doc/spytest/tests/routing/test_arp_analyzer.md
@@ -1,0 +1,44 @@
+# ARP Test Automation Analysis
+
+## 1. Topology Type
+- **Topology Identified:** `D1T1:2` (one DUT connected to a single traffic generator with two links).
+- **Inference:** The module-level fixture `arp_module_hooks` invokes `st.ensure_min_topology("D1T1:2")`, which requires a single SONiC DUT (D1) paired with traffic generator ports `T1D1P1` and `T1D1P2`. The subsequent handle retrieval `tgapi.get_handles_byname("T1D1P1", "T1D1P2")` and usage of those ports in traffic configuration confirm the two-link TG-to-DUT setup.
+
+## 2. Overall Test Case Purpose
+- **Primary Goal:** Validate that SONiC correctly handles dynamic ARP entry renewal without incurring packet loss while forwarding IPv4 traffic.
+- **Context within SONiC/SpyTest:** The test provisions IP addressing on physical and VLAN interfaces, drives ARP learning through a traffic generator, and verifies traffic continuity across ARP age-out and renewal cycles. This ensures ARP functionality and data-plane resilience in SONiC builds exercised through the SpyTest framework.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_ft_arp_dynamic_renew_traffic_test`
+- **Intent & Logic:**
+  - Sets ARP age-out time to 75 seconds on the DUT.
+  - Sends verification pings from both TG interfaces to confirm reachability and trigger ARP learning for interfaces `vars.D1T1P1` and VLAN interface `Vlan64`.
+  - Resets TG statistics and creates a bidirectional IPv4 traffic stream (`s1`) from TG port 2 to port 1 using VLAN tagging and the learned MAC of the DUT.
+  - Clears DUT interface counters, starts continuous traffic, waits beyond the ARP age-out interval (10 s sleep followed by additional 5 s) to force ARP renewal during active traffic, then stops the stream.
+  - Collects and validates traffic statistics using `tgapi.validate_tgen_traffic` with VLAN filtering; on failure, dumps interface counters and reports failure, otherwise reports success.
+- **Relevance:** Demonstrates that dynamic ARP entries are refreshed transparently during ongoing traffic and that no packet loss occurs through the renewal process, which is critical for maintaining L2/L3 connectivity in SONiC deployments.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `arp_module_hooks` (module scope, autouse) provisions the topology, configures IP/VLAN state on the DUT, creates TG interfaces, and performs cleanup after tests.
+  - `arp_func_hooks` (function scope, autouse) provides a placeholder for per-test setup/teardown (currently no extra logic).
+  - `fixture_ft_arp_dynamic_renew_traffic_test` resets ARP age-out to 60 seconds after the test to restore default behavior.
+- **Topology Constraints:** Requires availability of ports `T1D1P1` and `T1D1P2` connected between the TG and DUT, plus VLAN capability on `T1D1P2`.
+- **Libraries/Helpers:** Depends on SpyTest utilities (`st`, `tgapi`), routing/vlan APIs, and MAC/interface helpers to program the DUT and validate traffic.
+
+## 5. Key Inputs and Parameters
+- **Static Data (`data` object):** Predefines IP addresses, MAC addresses, VLAN ID 64, ARP age-out timers, and traffic queue mappings used throughout the test.
+- **Testbed Handles (`vars`, `tg_handler`, `tg`, `h1`, `h2`):** Obtained via SpyTest APIs to address DUT interfaces (`vars.D1T1P1`, `vars.D1T1P2`) and TG ports for traffic operations.
+- **CLI Type (`data.cli_type`):** Placeholder for selecting CLI backend (empty string defaults to platform CLI), passed into ARP configuration calls.
+
+## 6. External Libraries and Modules
+- `pytest`: Provides fixture and test management.
+- `spytest.SpyTestDict`, `st`, `tgapi`: SpyTest utilities for state storage, logging, device access, and traffic generator control.
+- `apis.routing.arp`: Offers ARP configuration helpers (e.g., `set_arp_ageout_time`).
+- `apis.routing.ip`: Manages IP interface configuration on the DUT.
+- `apis.system.interface`: Handles interface counter operations and other system-level interactions.
+- `apis.switching.vlan`: Creates VLANs and adds members on the DUT.
+- `apis.switching.mac`: Retrieves interface MAC addresses needed for traffic configuration.
+
+## 7. Unspecified Items
+- No additional requirements beyond those described above are declared in the test file; any other dependencies are **Not specified**.


### PR DESCRIPTION
## Summary
- add analyzer documentation covering the ARP dynamic renewal SpyTest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3b72daf10832f8482a34dc1f039e0