### PR TITLE
Add analysis for ARP static route long run test

### DIFF
--- a/docs/spytest_doc/spytest/tests/routing/test_arp_static_route_long_run_analyzer.md
+++ b/docs/spytest_doc/spytest/tests/routing/test_arp_static_route_long_run_analyzer.md
@@ -1,0 +1,84 @@
+# Test Case Analysis: `spytest/tests/routing/test_arp_static_route_long_run.py`
+
+## 1. Topology Type
+- **Identified Topology:** `D1T1:2` (one DUT with a two-port T1 traffic generator attachment).
+- **Inference:** The `init_vars()` helper invokes `st.ensure_min_topology("D1T1:2")`, which requests a topology consisting of a single DUT (`D1`) connected to a TGEN with two ports (`T1P1`, `T1P2`). Subsequent usage of `vars.D1T1P1`, `vars.D1T1P2`, and traffic generator handles obtained via `tgapi.get_handles_byname("T1D1P1", "T1D1P2")` reinforces this topology assumption.
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate that static routing and ARP configurations persist and operate correctly across different reboot scenarios (warm, fast, and cold) on a SONiC device.
+- **Context in SONiC/SpyTest:** The test ensures configuration resilience and data-plane continuity by confirming that:
+  - Static routes configured through vtysh remain programmed after reboots.
+  - Static ARP entries persist and dynamic ARP entries can be re-learned after device restarts.
+  - Warm reboot support is honored per platform capabilities defined in the SpyTest datastore constants.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_ft_arp_static_route_config_mgmt_verifying_config_with_warm_reboot`
+- **Intent & Logic:**
+  - Checks platform eligibility for warm reboot using `data.constants['WARM_REBOOT_SUPPORTED_PLATFORMS']`.
+  - Performs a warm reboot via `st.reboot(vars.D1, "warm")`.
+  - Waits for system stabilization, then verifies static route presence (`static_route_verify()`), dynamic ARP entry survival, and, for non-`click` UI devices, the static ARP entry.
+- **Relevance:** Confirms that warm reboot procedures do not disrupt saved static routing/ARP state, aligning with SONiC’s warm reboot expectations.
+
+### `test_ft_arp_static_route_config_mgmt_verifying_config_with_save_fast_reboot`
+- **Intent & Logic:**
+  - Triggers a fast reboot (`st.reboot(vars.D1, "fast")`).
+  - Post-reboot, re-validates static route configuration, regenerates dynamic ARP entries via traffic generator traffic (`adding_dynamic_arp()`), and checks that the DUT learns the entry.
+- **Relevance:** Ensures fast reboot maintains the saved static route and that the system can re-establish dynamic ARP connectivity quickly.
+
+### `test_ft_arp_static_route_config_mgmt_verifying_config_with_save_reboot`
+- **Intent & Logic:**
+  - Performs a standard cold reboot (`st.reboot(vars.D1)`).
+  - After reboot, verifies the static route configuration, recreates dynamic ARP traffic, and ensures the ARP entry is present.
+- **Relevance:** Validates baseline resilience of static route persistence and ARP learning through a full device restart.
+
+## Helper Functions and Fixtures
+- **Module-Level Fixture `arp_static_route_reboot_module_hooks`:**
+  - Autouse fixture configuring topology, test data, traffic generator handles, static routes (`adding_static_route()`), dynamic ARP entries (`adding_dynamic_arp()`), interface IPs, and static ARP entries before tests run.
+  - Performs pre-checks on static route and ARP entries, saves configuration via management CLI and `vtysh`, and performs cleanup (clearing IPs, routes, ARP entries) after the module executes.
+- **Function-Level Fixture `arp_static_route_reboot_func_hooks`:** Currently a placeholder performing no additional setup/teardown per test, but enforces a standardized hook location for future per-test logic.
+- **Helper `adding_static_route()`:** Configures interface IP, enables docker routing config mode, and creates the static route via `vtysh`.
+- **Helper `static_route_verify()`:** Polls for interface IP presence and static route availability using `ip_obj.verify_interface_ip_address` and `ip_obj.verify_ip_route` with retries via `poll_wait`.
+- **Helper `adding_dynamic_arp()`:** Programs traffic generator interface settings, sends a ping to induce dynamic ARP learning, waits, and confirms ARP table entries on the DUT.
+
+These helpers collectively establish the test environment, perform verification, and encapsulate repeated logic to support each reboot scenario test.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures & Utilities:**
+  - `st.ensure_min_topology` for topology validation.
+  - Autouse fixtures for environment setup/cleanup.
+  - Traffic generator handles obtained via `tgapi.get_handles_byname`.
+- **APIs & Helpers:**
+  - `arp_obj`, `ip_obj`, `bgp_obj`, and `rb_obj` modules for configuration and verification tasks.
+  - `poll_wait` utility to poll until configurations are applied.
+- **Topology Constraints:**
+  - Availability of a single DUT with two TGEN connections (`D1T1:2`), implying the presence of ports `vars.D1T1P1` and `vars.D1T1P2` and a traffic generator capable of ARP and ping operations.
+- **Platform Data:**
+  - Access to platform constants through `st.get_datastore(vars.D1, "constants", "default")` to verify warm reboot support.
+
+## 5. Key Inputs and Parameters
+- `data.static_arp_mac`, `data.static_arp_ip`: Define the static ARP entry that must persist.
+- `data.ipv4_address`, `data.ipv4_address_tgen`, `data.ipv4_address_network`, `data.mask`: Control interface addressing and the static route prefix.
+- `data.src_mac_addr`: Source MAC used by the traffic generator for ARP learning.
+- `data.platform`, `data.constants`: Device-specific attributes used to decide whether warm reboot tests are applicable.
+- Traffic generator configuration handles (`tg_handler`, `data.h1`) and ping parameters for inducing ARP learning.
+
+## 6. External Libraries and Modules
+- **PyTest (`pytest`):** Provides fixture management and test discovery.
+- **SpyTest Core (`st`, `tgapi`, `SpyTestDict`):**
+  - `st`: SpyTest session utilities for logging, topology management, reboot handling, and reporting results.
+  - `tgapi`: Interfaces with traffic generators for configuration and verification (ARP, ping).
+  - `SpyTestDict`: Convenient dictionary structure for test data storage.
+- **Routing/System API Modules:**
+  - `apis.routing.arp`: Manage and verify ARP entries.
+  - `apis.system.reboot`: Save configuration and manage reboots.
+  - `apis.system.basic`: Retrieve platform hardware SKU.
+  - `apis.routing.ip`: Configure IP addresses and static routes, and verify interface/route states.
+  - `apis.routing.bgp`: Enable docker routing config mode before route programming.
+- **Utilities:**
+  - `utilities.common.poll_wait`: Repeatedly polls verification functions with timeouts to accommodate asynchronous configuration application.
+
+## 7. Unspecified Items
+- Testbed inventory specifics beyond the `D1T1:2` requirement (e.g., exact platform models, interface identifiers) – **Not specified**.
+- Explicit references to testbed YAML or group variables – **Not specified**.
+- Detailed traffic generator hardware model and capabilities – **Not specified**.
+


### PR DESCRIPTION
## Summary
- add QA analysis markdown for `test_arp_static_route_long_run.py`
- document topology, purpose, subtests, dependencies, and inputs for static ARP route reboot coverage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3b82fd220832fa2684d22c64cd11b