### PR TITLE
Add analyzer doc for routing IP tests

### DIFF
--- a/docs/spytest_doc/spytest/tests/routing/test_ip_analyzer.md
+++ b/docs/spytest_doc/spytest/tests/routing/test_ip_analyzer.md
@@ -1,0 +1,73 @@
+# Test Analyzer: `spytest/tests/routing/test_ip.py`
+
+## 1. Topology Type
+- **Topology**: Dual-DUT (D1 & D2) with traffic generator connections and four inter-DUT links.
+- **Evidence**: The module-scoped fixture calls `st.ensure_min_topology("D1T1:2", "D2T1:2", "D1D2:4")`, requiring two testbed devices, each with two connections to a traffic generator (T1) and four links between the DUTs.【F:spytest/tests/routing/test_ip.py†L66-L119】
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal**: Validate IPv4/IPv6 routing functionality across VLAN interfaces, port-channels, and physical links, including static routes, BGP route scaling, interface order display, and RIF counter accuracy.
+- **Scope in SONiC/SpyTest**: Ensures SONiC DUTs handle mixed Layer2/Layer3 configurations, route advertisement/learning, neighbor reachability, traffic forwarding (including blackhole scenarios), and instrumentation (show commands, counters) when orchestrated via SpyTest utilities.【F:spytest/tests/routing/test_ip.py†L66-L595】【F:spytest/tests/routing/test_ip.py†L598-L959】
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_l3_v4_route_po_1`
+- **Intent**: Exercise large-scale IPv4 route advertisement learned over the port-channel-facing interface using a traffic generator-driven BGP peer.
+- **Logic**: Dumps ASIC state, invokes `create_v4_route(30000)` to configure BGP, advertise 30k prefixes, and verify traffic statistics for learned routes.【F:spytest/tests/routing/test_ip.py†L241-L253】【F:spytest/tests/routing/test_ip.py†L159-L239】
+- **Why It Matters**: Validates route scale handling and forwarding over the aggregated interface, stressing control/data plane convergence.
+
+### `test_ft_ping_v4_v6_vlan`
+- **Intent**: Confirm basic IPv4 and IPv6 reachability across VLAN routing interfaces between D1 and D2.
+- **Logic**: Issues IPv4/IPv6 pings using pre-configured VLAN SVI addresses; fails on any loss.【F:spytest/tests/routing/test_ip.py†L327-L343】
+- **Importance**: Serves as a sanity check for dual-stack VLAN routing set up in module fixture.
+
+### `test_ft_ping_v4_v6_after_ip_change_pc`
+- **Intent**: Ensure port-channel routing resiliency during address reconfiguration and IPv6 neighbor handling.
+- **Logic**: Verifies port-channel state, performs IPv4/IPv6 ping tests, removes existing IPs, reapplies new ones, configures static NDP entries, validates reachability after changes.【F:spytest/tests/routing/test_ip.py†L345-L399】
+- **Importance**: Confirms dynamic reconfiguration robustness and NDP/ARP correctness on LAG interfaces.
+
+### `test_ft_ip6_static_route_traffic_forward_blackhole`
+- **Intent**: Validate IPv6 static route forwarding and blackhole behavior alongside RIF counter updates.
+- **Logic**: Sends IPv6 traffic through static routes, verifies counters and traffic delivery, reprograms next hop to blackhole, ensures drop by expecting traffic validation failure, and records counter behavior.【F:spytest/tests/routing/test_ip.py†L402-L500】
+- **Importance**: Tests static routing correctness, monitoring instrumentation, and blackhole policy enforcement for IPv6.
+
+### `test_ft_ip_static_route_traffic_forward`
+- **Intent**: Validate IPv4 static route forwarding, including RIF counter monitoring across link flap events.
+- **Logic**: Generates IPv4 traffic via traffic generator, checks aggregate stats, toggles physical port, clears counters, revalidates traffic and counter increments, and reports RIF counter status.【F:spytest/tests/routing/test_ip.py†L503-L595】
+- **Importance**: Ensures IPv4 static route forwarding stability and observability through counter metrics under port state changes.
+
+### `test_ft_ip_v4_v6_L2_L3_translation`
+- **Intent**: Validate transitions between Layer2 and Layer3 modes on the same ports while maintaining IPv4/IPv6 connectivity.
+- **Logic**: Performs routed pings, tears down static routes and addresses, converts interfaces to VLAN membership, drives tagged L2 traffic, reverts to routed configuration, and confirms dual-stack reachability after reconfiguration.【F:spytest/tests/routing/test_ip.py†L598-L660】
+- **Importance**: Tests operational flexibility when ports switch between L2 and L3 roles without losing functionality.
+
+### `test_ft_verify_interfaces_order`
+- **Intent**: Verify `show ip/ipv6 interfaces` output lists interfaces in alphanumeric order.
+- **Logic**: Allocates free ports, assigns IPv4/IPv6 addresses, captures CLI output, compares order to sorted list, and reports discrepancies. Cleans up via fixture `ft_verify_interfaces_order_hooks`.【F:spytest/tests/routing/test_ip.py†L688-L742】【F:spytest/tests/routing/test_ip.py†L744-L759】
+- **Importance**: Ensures deterministic interface listings aiding operational troubleshooting scripts.
+
+### Helper Functions & Fixtures
+- `create_v4_route` / `create_v6_route`: Configure DUT BGP sessions with TGen, advertise routes, and validate traffic; reused by route scale tests.【F:spytest/tests/routing/test_ip.py†L159-L324】
+- `rifcounter_validation`: Shared utility verifying RIF counters for multiple tests.【F:spytest/tests/routing/test_ip.py†L760-L833】
+- `ip_module_hooks`: Autouse module fixture provisioning VLANs, port-channel, static routes, and testbed addresses, plus teardown.【F:spytest/tests/routing/test_ip.py†L66-L126】
+- `ft_verify_interfaces_order_hooks` & `ceta_31902_fixture`: Provide setup/cleanup for specific tests (latter unused within file but configures VLAN-based host routing scenario).【F:spytest/tests/routing/test_ip.py†L744-L786】【F:spytest/tests/routing/test_ip.py†L788-L827】
+
+## 4. Dependencies and Prerequisites
+- **Fixtures**: `ip_module_hooks` (autouse module), `ip_func_hooks` (autouse function), optional fixtures `ft_verify_interfaces_order_hooks`, `ceta_31902_fixture` for scenario-specific setups.【F:spytest/tests/routing/test_ip.py†L66-L133】【F:spytest/tests/routing/test_ip.py†L744-L827】
+- **Topology Constraints**: Requires two SONiC DUTs with four interconnects and traffic generator connections as enforced by `st.ensure_min_topology` call.【F:spytest/tests/routing/test_ip.py†L66-L119】
+- **Test Equipment**: Traffic generator integration via `tgapi` for BGP emulation and traffic validation is mandatory for route scale and static route tests.【F:spytest/tests/routing/test_ip.py†L159-L595】
+
+## 5. Key Inputs and Parameters
+- **Address Pools**: IPv4/IPv6 address lists (`data.ip4_addr`, `data.ip6_addr`) supply interface and route endpoints.【F:spytest/tests/routing/test_ip.py†L22-L45】
+- **Routing Parameters**: Autonomous system numbers (`data.as_num`, `data.remote_as_num`), static route prefixes (`data.static_ip_rt`, `data.static_ip6_rt`), and route-map names (`data.routemap`) drive BGP/static configurations.【F:spytest/tests/routing/test_ip.py†L43-L48】【F:spytest/tests/routing/test_ip.py†L111-L115】【F:spytest/tests/routing/test_ip.py†L190-L208】
+- **Interface Identifiers**: VLAN IDs, port-channel name, MAC addresses, and traffic generator rates (`data.rate_pps`, `data.pkts_per_burst`) are used across tests for configuration and validation.【F:spytest/tests/routing/test_ip.py†L36-L44】【F:spytest/tests/routing/test_ip.py†L74-L75】【F:spytest/tests/routing/test_ip.py†L92-L110】
+- **Counters & Masks**: `data.ipv4_mask`, `data.ipv6_mask`, and `data.no_of_ports` define addressing increments and interface counts for order verification.【F:spytest/tests/routing/test_ip.py†L49-L52】【F:spytest/tests/routing/test_ip.py†L688-L717】
+
+## 6. External Libraries and Modules
+- **SpyTest Core**: `spytest.st`, `tgapi`, `SpyTestDict` provide logging, topology utilities, and traffic generator APIs.【F:spytest/tests/routing/test_ip.py†L7-L20】
+- **Routing/Switching APIs**: Modules `apis.routing.ip`, `apis.switching.vlan`, `apis.switching.portchannel`, `apis.routing.bgp`, `apis.routing.route_map`, `apis.routing.arp` abstract SONiC configuration and verification for IP, VLANs, LAGs, BGP, route-maps, and neighbor discovery.【F:spytest/tests/routing/test_ip.py†L9-L17】
+- **System Utilities**: `apis.system.basic`, `apis.system.interface`, and `apis.common.asic` fetch hardware info, manipulate interfaces, and collect ASIC dumps.【F:spytest/tests/routing/test_ip.py†L12-L15】
+- **Utility Helpers**: `utilities.common.random_vlan_list`, `utilities.utils.rif_support_check`, `report_tc_fail` support randomized VLAN selection, platform capability detection, and reporting.【F:spytest/tests/routing/test_ip.py†L19-L20】
+- **Standard Libraries**: `random`, `math`, `re`, and `pytest` aid data preparation, calculations, string parsing, and test decoration.【F:spytest/tests/routing/test_ip.py†L2-L5】
+
+## 7. Unspecified Items
+- Any additional topology diagrams, external configuration files (e.g., `testbed.yaml`), or traffic generator hardware specifics are **Not specified** within this test file.
+


### PR DESCRIPTION
## Summary
- add a SpyTest QA analyzer document for `spytest/tests/routing/test_ip.py`
- summarize topology, dependencies, helper routines, and every test function

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3b90bd834832f83beaee085a3f8b6