### PR TITLE
Add analyzer for L3 performance routing tests

### DIFF
--- a/docs/spytest_doc/routing/test_l3_performance_analyzer.md
+++ b/docs/spytest_doc/routing/test_l3_performance_analyzer.md
@@ -1,0 +1,58 @@
+# L3 Performance Test Analyzer
+
+## 1. Topology Type
+- **Topology:** D1T1 with two traffic generator links ("D1T1:2").
+- **Inference:** The module-level fixture calls `st.ensure_min_topology("D1T1:2")`, which requires one DUT (Device 1) connected to a single traffic generator (T1) with two links (`vars.T1D1P1`, `vars.T1D1P2`). These handles are subsequently used to pull TG/DUT port references, confirming the D1-to-T1, two-port topology.【F:spytest/tests/routing/test_l3_performance.py†L32-L47】
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate SONiC L3 performance enhancements by measuring BGP route installation/withdrawal timings, confirming route table updates at the ASIC and control-plane levels, and benchmarking CLI responsiveness for route display and configuration workflows.
+- **SONiC/SpyTest Context:** The suite orchestrates DUT and traffic generator setup, advertises large route sets through BGP, and leverages SpyTest utilities to verify hardware route counters, CLI outputs, and operational stability under heavy control-plane activity.【F:spytest/tests/routing/test_l3_performance.py†L15-L214】【F:spytest/tests/routing/test_l3_performance.py†L262-L509】
+
+## 3. Detailed Breakdown of Sub-Testcases
+### 3.1 `test_ft_l3_performance_enhancements_v4_route_intstall_withdraw`
+- **Intent & Logic:**
+  - Uses `fixture_v4` to establish IPv4 BGP adjacency between the DUT and TG, advertising up to `data.test_bgp_route_count` routes based on platform SKU sizing.【F:spytest/tests/routing/test_l3_performance.py†L218-L290】【F:spytest/tests/routing/test_l3_performance.py†L305-L328】
+  - Measures route withdrawal by commanding the TG to withdraw routes and asserting that ASIC and BGP summaries return to baseline counts.【F:spytest/tests/routing/test_l3_performance.py†L330-L360】
+  - Optionally validates data-path counters when traffic generation is enabled and records elapsed time for re-advertisement (installation) and withdrawal cycles.【F:spytest/tests/routing/test_l3_performance.py†L362-L448】
+  - Exercises `show ip route` via Click, vtysh, and optionally Klish to benchmark route display latency under large routing tables.【F:spytest/tests/routing/test_l3_performance.py†L402-L436】
+- **Relevance:** Demonstrates DUT scalability for massive IPv4 route churn, ensuring both ASIC programming speed and management-plane visibility remain within expectations.
+
+### 3.2 `test_cli_validation_ip_address`
+- **Intent & Logic:**
+  - Adds VLANs 101–121 and times bulk IPv4 address configuration/removal using Click CLI commands, validating operation completion and logging elapsed time.【F:spytest/tests/routing/test_l3_performance.py†L451-L484】
+  - When Klish is supported, repeats the timing measurements for equivalent configuration/removal commands via Klish.【F:spytest/tests/routing/test_l3_performance.py†L486-L501】
+- **Relevance:** Quantifies CLI responsiveness for repetitive L3 interface configuration tasks, feeding into overall performance characterization of control-plane workflows.
+
+### 3.3 `test_cli_validation_bgp_router_config`
+- **Intent & Logic:**
+  - Uses helper `bgp_router_cli_validation` to batch-create BGP neighbors for AS 100 across multiple VLAN interfaces, measuring execution time via vtysh and optionally Klish.【F:spytest/tests/routing/test_l3_performance.py†L439-L449】【F:spytest/tests/routing/test_l3_performance.py†L503-L519】
+- **Relevance:** Benchmarks the efficiency of CLI-based BGP configuration at scale, complementing the route performance metrics gathered in other tests.
+
+### Helper Fixtures and Functions
+- `l3_performance_enhancements_module_hooks`: Provides module-level setup/cleanup—configures DUT interfaces, BGP neighbors, collects default route counts, and handles topology detection. Ensures consistent environment for all tests.【F:spytest/tests/routing/test_l3_performance.py†L29-L128】
+- `fixture_v4` / `fixture_v6`: Per-test TG configuration for IPv4/IPv6 BGP peers, including neighbor bring-up and teardown. Only `fixture_v4` is consumed in this file; `fixture_v6` is prepared for potential IPv6 scenarios.【F:spytest/tests/routing/test_l3_performance.py†L218-L309】
+- Utility functions (`check_intf_traffic_counters`, `check_asic_route_count`, `verify_bgp_route_count`, `show_ip_route_validation_cli`, `bgp_router_cli_validation`): Provide reusable validation steps for traffic counters, ASIC route counts, BGP summaries, CLI timing, and scripted configuration sequences supporting the main tests.【F:spytest/tests/routing/test_l3_performance.py†L94-L217】【F:spytest/tests/routing/test_l3_performance.py†L310-L448】
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - Module fixture `l3_performance_enhancements_module_hooks` (auto-used) and function fixtures `fixture_v4` / `fixture_v6` (explicit). These ensure TG/DUT links, BGP setup, and environment cleanup occur for every test run.【F:spytest/tests/routing/test_l3_performance.py†L29-L309】
+- **Topology Constraints:** Requires D1T1:2 setup with TG connectivity on two DUT interfaces (`D1T1P1`, `D1T1P2`).【F:spytest/tests/routing/test_l3_performance.py†L32-L47】
+- **Hardware Considerations:** Adjusts advertised route count based on hardware SKU lists and CLI type, implying platform-dependent capacity planning.【F:spytest/tests/routing/test_l3_performance.py†L49-L93】
+- **Traffic Generator Access:** Relies on `tgapi` handles for interface and BGP configuration, as well as potential traffic generation.【F:spytest/tests/routing/test_l3_performance.py†L34-L36】【F:spytest/tests/routing/test_l3_performance.py†L234-L286】
+
+## 5. Key Inputs and Parameters
+- `data.test_bgp_route_count`: Number of routes advertised; tuned per hardware SKU to stress realistic limits.【F:spytest/tests/routing/test_l3_performance.py†L49-L93】
+- `data.includeTraffic`: Flag controlling whether additional traffic streams and counter checks run during route churn testing.【F:spytest/tests/routing/test_l3_performance.py†L27-L28】【F:spytest/tests/routing/test_l3_performance.py†L362-L372】
+- Interface IPs/ASNs (`data.my_ip_addr`, `data.neigh_ip_addr`, etc.): Define addressing for DUT and TG during BGP session establishment.【F:spytest/tests/routing/test_l3_performance.py†L17-L28】【F:spytest/tests/routing/test_l3_performance.py†L67-L86】
+- `cli_type`: Determines CLI flavor (click/klish) and threshold adjustments for counter matching, affecting subsequent checks and command paths.【F:spytest/tests/routing/test_l3_performance.py†L41-L57】【F:spytest/tests/routing/test_l3_performance.py†L102-L130】
+- Default route counts (`def_v4_route_count`, `def_v6_route_count`): Baselines used when asserting route table deltas during install/withdraw cycles.【F:spytest/tests/routing/test_l3_performance.py†L74-L124】【F:spytest/tests/routing/test_l3_performance.py†L340-L348】
+
+## 6. External Libraries and Modules
+- **`pytest`**: Provides fixture and test execution framework, including marking inventory metadata.【F:spytest/tests/routing/test_l3_performance.py†L1-L5】【F:spytest/tests/routing/test_l3_performance.py†L322-L325】
+- **`spytest` Toolkit (`st`, `tgapi`, `SpyTestDict`)**: Core SpyTest utilities for logging, topology handling, TG control, and shared data structures.【F:spytest/tests/routing/test_l3_performance.py†L5-L44】【F:spytest/tests/routing/test_l3_performance.py†L218-L286】
+- **`apis.routing.ip`, `apis.system.port`, `apis.routing.bgp`, `apis.system.basic`, `apis.common.asic`, `apis.switching.vlan`**: SONiC/SpyTest API layers for configuring IPs, querying counters, managing BGP neighbors, fetching hardware details, interacting with ASIC route tables, and managing VLANs.【F:spytest/tests/routing/test_l3_performance.py†L7-L14】【F:spytest/tests/routing/test_l3_performance.py†L67-L514】
+- **`utilities.common.filter_and_select`**: Helper for filtering command outputs when verifying BGP summaries.【F:spytest/tests/routing/test_l3_performance.py†L12-L13】【F:spytest/tests/routing/test_l3_performance.py†L128-L178】
+- **Standard Library (`datetime`)**: Used for timing measurements throughout tests.【F:spytest/tests/routing/test_l3_performance.py†L2-L3】【F:spytest/tests/routing/test_l3_performance.py†L352-L517】
+
+## 7. Unspecified Items
+- IPv6-specific validation steps, CLI thresholds, and traffic generation parameters beyond what is described in the file are **Not specified** within this test case.【F:spytest/tests/routing/test_l3_performance.py†L27-L309】


### PR DESCRIPTION
## Summary
- add QA analyzer documentation for the L3 performance routing test suite

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3ba8c8b28832fb8ef258fda910111