### PR TITLE
Add TACACS test suite analyzer documentation

### DIFF
--- a/docs/spytest_doc/security/test_tacacs_analyzer.md
+++ b/docs/spytest_doc/security/test_tacacs_analyzer.md
@@ -1,0 +1,64 @@
+# TACACS Test Suite Analysis
+
+## 1. Topology Type
+- **Identified Topology:** Single-DUT topology (`D1`).
+- **Inference:** The module-level fixture calls `st.ensure_min_topology("D1")`, which provisions the minimum required topology consisting of a single device under test. No neighbor devices or multi-DUT requirements are referenced elsewhere in the test file.
+
+## 2. Overall Test Case Purpose
+- **Primary Goal:** Validate TACACS+ authentication behavior on a SONiC device, including default PAM artifacts, failthrough behavior between TACACS+ and local authentication, and server priority handling.
+- **Context within SONiC/SpyTest:** These tests ensure that the device correctly integrates with external TACACS+ servers for SSH login, adheres to AAA configuration expectations, and handles multiple TACACS+ servers according to priority and failover rules. This aligns with SONiC security validation objectives in SpyTest by verifying centralized authentication mechanisms.
+
+## 3. Detailed Breakdown of Sub-Testcases
+- **`test_ft_tacacs_ssh_login_with_tacacs_operations`**
+  - **Intent & Logic:** Confirms that enabling TACACS+ authentication produces the required PAM configuration files (`common-auth` and `common-auth-sonic`) on the device. Fails if either file is missing.
+  - **Relevance:** Verifies foundational configuration artifacts generated when TACACS+ is enabled, ensuring the authentication stack is properly prepared before more advanced checks.
+
+- **`test_ft_tacacs_enable_disable_failthrough`**
+  - **Intent & Logic:**
+    1. Adds a secondary TACACS+ server and attempts SSH with local credentials when AAA is `tacacs+ local` and failthrough is disabled—expects failure because TACACS+ should take precedence.
+    2. Confirms TACACS+ credentials succeed in the same state.
+    3. Reorders AAA to `local tacacs+` and verifies local logins succeed while TACACS+ fails (since TACACS+ is now fallback and failthrough remains disabled).
+    4. Re-enables `tacacs+ local` with failthrough enabled and checks both local and TACACS+ credentials succeed.
+  - **Relevance:** Validates AAA failthrough behavior between local and TACACS+ authentication paths, ensuring the device respects the configured order and failthrough toggle.
+
+- **`test_ft_tacacs_ssh_login_highest_priorityserver`**
+  - **Intent & Logic:** Attempts SSH login using credentials associated with the highest-priority TACACS+ server, expecting success, and then deletes the first server entry. Ensures prioritization is honored when multiple servers exist.
+  - **Relevance:** Confirms TACACS+ server priority ordering and failover readiness, crucial for redundancy scenarios.
+
+### Helper Functions and Fixtures
+- **`tacacs_module_hooks` (module autouse fixture):**
+  - Establishes topology, fetches TACACS service parameters, configures TACACS+ server(s), enables `tacacs+ local` AAA, and cleans up (including AAA defaults and server removal) after tests.
+- **`tacacs_func_hooks` (function autouse fixture):**
+  - Placeholder for per-test setup/teardown; currently performs no actions.
+- **`ensure_device_ipaddress`:** Retrieves the management IP to enable SSH attempts.
+- **`config_default_tacacs_properties`:** Resets TACACS+ properties to defaults during teardown.
+- **`verify_tacacs_server_reachability` / `verifying_tacacs_config`:** Provide diagnostics for verifying reachability and configuration if logins fail.
+- **`debug_info`:** Invoked on failures to collect TACACS diagnostics for the failthrough test.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:** `tacacs_module_hooks` and `tacacs_func_hooks` are autouse, ensuring setup/cleanup without explicit inclusion.
+- **Topology Constraint:** Requires at least one SONiC DUT (`D1`).
+- **External Services:** TACACS+ service definitions with at least two host entries are required in `testbed.yaml`/service info to supply IPs, priorities, and credentials.
+- **Cleanup Dependencies:** Ability to reset AAA and TACACS server configuration plus clear VLAN configuration (`clear_vlan_configuration`).
+
+## 5. Key Inputs and Parameters
+- **Service Parameters:** Pulled via `ensure_service_params` for TACACS hosts—IP addresses, TCP port, shared secret (`passkey`), priority, timeout, auth type.
+- **Credentials:** TACACS+ users (`username`, `password`, `username1`, `password1`) and local admin credentials (`local_username`, `local_password`, `local_password2`).
+- **AAA Settings:** Strings such as `'tacacs+ local'`, `'local tacacs+'`, and failthrough mode toggles guide authentication order.
+- **Connection Details:** `data.ip_address` (management IP) and `data.ssh_port` control SSH attempts.
+
+## 6. External Libraries and Modules
+- **`pytest`:** Provides fixture and marker infrastructure.
+- **`spytest.st` & `SpyTestDict`:** SpyTest utilities for logging, topology validation, and structured storage of test data.
+- **`apis.security.tacacs`:** TACACS+ configuration and verification APIs used to add/delete servers, configure AAA, and validate server state.
+- **`apis.system.connection`:** SSH client utilities for attempting logins.
+- **`apis.routing.ip`:** Supplies `ping` functionality for reachability checks.
+- **`apis.system.basic`:** Device file-system and interface inspection helpers (e.g., verifying PAM files, retrieving `ifconfig`).
+- **`apis.security.rbac.ssh_call`:** Imported but not used; likely provides additional SSH capabilities for RBAC scenarios.
+- **`apis.switching.vlan.clear_vlan_configuration`:** Used in teardown to reset VLAN state.
+- **`utilities.utils.ensure_service_params`:** Reads service configuration parameters from the testbed or inventory.
+- **`utilities.common.poll_wait`:** Imported but unused; typically provides polling utilities.
+
+## 7. Unspecified Items
+- Testbed specifics (exact TACACS server IPs, credentials source files) – **Not specified**.
+- Detailed behavior of imported API functions (e.g., success/failure criteria of `connect_to_device`) – **Not specified**.


### PR DESCRIPTION
## Summary
- document the TACACS security test suite topology, intent, and dependencies
- outline detailed behavior of each TACACS authentication sub-test

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d3c01ad024832faa4874ef2b880720