### PR TITLE
Add analyzer documentation for system box services test

### DIFF
--- a/docs/spytest_doc/system/test_box_services_analyzer.md
+++ b/docs/spytest_doc/system/test_box_services_analyzer.md
@@ -1,0 +1,40 @@
+# System Box Services Test Automation Analysis
+
+## 1. Topology Type
+- **Topology Identified:** Single-DUT topology (`D1`).
+- **Inference:** The module-level fixture `box_service_module_hooks` invokes `st.ensure_min_topology("D1")`, which asserts that at least one DUT (denoted `D1`) is present in the testbed. No traffic-generator ports or neighbor devices are referenced, reinforcing that this test only requires a standalone SONiC device.
+
+## 2. Overall Test Case Purpose
+- **Primary Goal:** Validate that the SONiC CLI command `show uptime` (queried via `get_system_uptime_in_seconds`) returns monotonically increasing system uptime values over time.
+- **Context within SONiC/SpyTest:** The test ensures that the SONiC management plane accurately reports system uptime via SpyTest automation, confirming reliability of basic system diagnostics and monitoring interfaces.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_ft_system_uptime`
+- **Intent & Logic:**
+  - Retrieves testbed variables through `st.get_testbed_vars()` and caches the DUT handle `vars.D1`.
+  - Logs the initial uptime in seconds using `boxserv_obj.get_system_uptime_in_seconds(vars.D1)`.
+  - Waits for 60 seconds (`st.wait(60)`) to allow uptime to advance.
+  - Calculates the expected uptime window (`initial_uptime + 60` to `initial_uptime + 120`).
+  - Re-queries the system uptime and validates that the reported value falls within the expected window, asserting monotonic and approximately real-time progression.
+  - Reports failure via `st.report_fail` if the uptime is outside the acceptable range; otherwise reports success with `st.report_pass`.
+- **Relevance:** Confirms that the fundamental system service responsible for tracking and exposing uptime is functioning correctly, providing confidence in baseline system health reporting within SONiC.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `box_service_module_hooks` (module scope, autouse) ensures the required topology (`D1`) is available before tests execute.
+  - `box_service_func_hooks` (function scope, autouse) provides a placeholder for per-test setup/teardown (currently no additional logic).
+- **Topology Constraints:** Requires access to a single SONiC DUT (`D1`) capable of responding to uptime queries.
+- **Libraries/Helpers:** Relies on SpyTest core utilities (`st`) for topology management, logging, waiting, and reporting, along with the box services API for retrieving uptime.
+
+## 5. Key Inputs and Parameters
+- `vars.D1`: Obtained from SpyTest testbed variables, it identifies the DUT against which the uptime command is executed. Its presence determines the target device for the validation.
+- Wait interval (`60` seconds): Hardcoded delay that defines the measurement window for evaluating uptime progression.
+- Calculated thresholds (`initial_uptime + 60`, `initial_uptime + 120`): Derived values used to verify that the measured uptime is within an expected range.
+
+## 6. External Libraries and Modules
+- `pytest`: Supplies fixture management and test discovery.
+- `spytest.st`: SpyTest service module used for topology setup, logging, waits, and reporting outcomes.
+- `apis.system.box_services`: Provides the helper `get_system_uptime_in_seconds` to query system uptime from the SONiC device.
+
+## 7. Unspecified Items
+- Testbed YAML specifics, device inventory details, or additional configuration parameters beyond the single-DUT requirement are **Not specified** in this file.


### PR DESCRIPTION
## Summary
- add analyzer documentation for the SpyTest system box services test case

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da11f833508328b4c0f6b853da14b5