### PR TITLE
Add analyzer documentation for device management test

### DIFF
--- a/docs/spytest_doc/system/test_device_mgmt_analyzer.md
+++ b/docs/spytest_doc/system/test_device_mgmt_analyzer.md
@@ -1,0 +1,42 @@
+# Device Management Test Analysis
+
+## 1. Topology Type
+- **Topology**: Single DUT with console-only access.
+- **Inference**: The module-level fixture `mgmt_module_hooks` calls `st.ensure_min_topology("D1", "CONSOLE_ONLY")`, indicating the test requires only one device (alias `D1`) reachable through its management console.
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal**: Validate that a SONiC device can transition its management interface (`eth0`) between DHCP-assigned and statically configured IP addresses while maintaining reachability to the default gateway.
+- **SONiC/SpyTest Context**: Demonstrates management-plane configuration management using SpyTest utilities (e.g., interface configuration, reachability checks) to ensure reliability of management access workflows.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_ft_ip_static_ip_on_mgmt_intrf`
+- **Intent & Logic**:
+  1. Ensures the management interface obtains an address via DHCP and asserts the IP is present.
+  2. Captures the DHCP-provided IP, netmask, and gateway, then reconfigures the interface with the same values as static parameters.
+  3. Verifies connectivity to the gateway using ICMP while the interface holds the static configuration.
+  4. Removes the static IP to confirm the interface is cleared of the configuration.
+  5. Re-enables DHCP on the interface and validates gateway reachability once more.
+- **Relevance**: Confirms that the DUT correctly handles configuration lifecycle operations (DHCP → static → DHCP) on the management interface without losing connectivity—a critical aspect of device management resiliency.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures**:
+  - `mgmt_module_hooks` (module, autouse): Establishes the minimum topology (`D1`, `CONSOLE_ONLY`), records the DUT handle, and adjusts module parameters (`tryssh=0`) to rely on console access.
+  - `mgmt_func_hooks` (function, autouse): Placeholder fixture (currently no body) ensuring a consistent hook for per-test setup/teardown should future logic be required.
+- **Topology Constraints**: Requires a single DUT accessible via console and capable of DHCP/static IP configuration on `eth0`.
+- **Libraries/Helpers**: Relies on SpyTest API modules (`apis.system.interface`, `apis.system.basic`, `apis.routing.ip`) for interface configuration, system info retrieval, and reachability checks.
+
+## 5. Key Inputs and Parameters
+- `data.dut`: DUT identifier produced by `st.ensure_min_topology`.
+- `data.interface`: Hardcoded as `eth0`, the management interface under test.
+- `data.ip_address`, `data.netmask`, `data.gateway`: Captured from DHCP lease via SpyTest helpers and reused for static configuration and validation steps.
+- `st.set_module_params(tryssh=0)`: Configures test execution to avoid SSH fallback, enforcing console usage.
+
+## 6. External Libraries and Modules
+- `pytest`: Provides fixture and test case declaration mechanisms.
+- `spytest.st`, `SpyTestDict`: Core SpyTest utilities for topology management, logging, reporting, and shared data storage across fixtures/tests.
+- `apis.routing.ip` (`ping_obj`): Offers the `ping` helper used to validate IP reachability.
+- `apis.system.interface` (`intf_obj`): Supplies interface configuration functions (enable DHCP, configure static IP, remove IP).
+- `apis.system.basic` (`basic_obj`): Retrieves interface details such as assigned IP addresses, netmask, and gateway.
+
+## 7. Unspecified Items
+- Details about DHCP server configuration, specific gateway IP, or additional environmental prerequisites beyond console access are **Not specified** in the test file.


### PR DESCRIPTION
## Summary
- add analyzer documentation for the device management SpyTest test covering management interface IP transitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da12a9a4d88328bba4a269e467b298