### PR TITLE
Add analysis doc for SpyTest device management test

### DIFF
--- a/docs/spytest_doc/system/test_device_mgmt_analyzer.md
+++ b/docs/spytest_doc/system/test_device_mgmt_analyzer.md
@@ -1,0 +1,46 @@
+# `test_device_mgmt.py` Test Case Analysis
+
+## 1. Topology Type
+- **Identified Topology:** Single-DUT console-only access (`D1`, `CONSOLE_ONLY`).
+- **Inference:** The module-level fixture `mgmt_module_hooks` calls `st.ensure_min_topology("D1", "CONSOLE_ONLY")`, which asserts the testbed has one device-under-test reachable through console management. This is the only explicit topology reference in the file, indicating the test requires only console connectivity and no neighbor devices.
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate management interface behavior—specifically switching the management interface (`eth0`) between DHCP-assigned and statically configured IP addresses while maintaining reachability.
+- **Broader SONiC/SpyTest Context:** Management connectivity is foundational for SONiC device administration. The test ensures SpyTest can configure SONiC's management port with both DHCP and static addressing, verify reachability via ping, and return the interface to DHCP, thereby confirming basic management-plane resilience and configuration workflows.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_ft_ip_static_ip_on_mgmt_intrf`
+- **Intent and Flow:**
+  1. Enable DHCP on `eth0` and pause (`st.wait(5)`) to obtain an address.
+  2. Retrieve current IP information via `basic_obj.get_ifconfig_inet` and fail the test if none is returned, ensuring DHCP assignment succeeded.
+  3. Extract the assigned IP, netmask, and default gateway using `basic_obj` helpers and reapply them as a static configuration through `intf_obj.config_static_ip_to_interface`.
+  4. Validate connectivity to the gateway using `ping_obj.ping`, capturing errors if reachability fails under the static configuration.
+  5. Remove the static IP (`intf_obj.delete_ip_on_interface_linux`) and confirm the interface no longer holds that address.
+  6. Re-enable DHCP and perform another ping to verify connectivity when DHCP reassumes control.
+  7. Report aggregated results via `st.report_result`.
+- **Relevance:** Demonstrates that management interface configuration changes (DHCP ↔ static) are applied correctly without disrupting connectivity, a critical scenario for remote device management and automation workflows.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `mgmt_module_hooks` (module scope, autouse) ensures the required topology, sets module parameters (`tryssh=0`), and stores the DUT handle.
+  - `mgmt_func_hooks` (function scope, autouse) is present but currently performs no actions, serving as a placeholder for per-test setup/teardown.
+- **SpyTest Helpers:** `st.ensure_min_topology`, `st.set_module_params`, `st.wait`, `st.log`, `st.error`, `st.report_fail`, and `st.report_result` provide topology validation, logging, timing, and reporting utilities.
+- **Topology Constraint:** Requires a single SONiC DUT accessible via console for management interface manipulation. No neighbor devices are required.
+
+## 5. Key Inputs and Parameters
+- **`data.interface`** (`'eth0'`): Specifies the management interface under test.
+- **Dynamic IP information** gathered at runtime (`data.ip_address`, `data.netmask`, `data.gateway`): Derived from DHCP lease and reused for static configuration validation.
+- **Gateway reachability target:** The default gateway returned by `basic_obj.get_ifconfig_gateway`, used for ping validation.
+- **Timing Parameter:** A fixed wait of 5 seconds after enabling DHCP, assuming sufficient time for lease acquisition.
+
+## 6. External Libraries and Modules
+- **`pytest`**: Provides the test framework, fixtures, and markers (e.g., `@pytest.mark.static_ip_on_mgmt_intrf`).
+- **`spytest` utilities (`st`, `SpyTestDict`)**: Core SpyTest APIs for topology handling, logging, data storage, and result reporting.
+- **`apis.routing.ip` (`ping_obj`)**: Supplies the `ping` function to test reachability.
+- **`apis.system.interface` (`intf_obj`)**: Offers management interface configuration helpers (enabling DHCP, applying/removing static IPs).
+- **`apis.system.basic` (`basic_obj`)**: Provides utilities to fetch interface configuration details (IP address, netmask, gateway).
+
+## 7. Unspecified Items
+- **Additional topology details (e.g., physical connections, VLANs):** Not specified.
+- **External configuration sources (testbed.yaml, group_vars, CLI parameters):** Not specified within this file.
+- **Error recovery or rollback steps beyond those described:** Not specified.


### PR DESCRIPTION
## Summary
- add a SpyTest analyzer document for the management interface test case
- describe topology, test intent, dependencies, and key parameters for `test_device_mgmt.py`

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68da148cec38832893a6aa41f34d66f7