### PR TITLE
Add analyzer documentation for NTP system tests

### DIFF
--- a/docs/spytest_doc/system/test_ntp_analyzer.md
+++ b/docs/spytest_doc/system/test_ntp_analyzer.md
@@ -1,0 +1,66 @@
+# NTP System Test Analyzer
+
+## 1. Topology Type
+- **Topology**: Single-DUT management network topology (one SONiC device connected via management plane).
+- **Inference**: The test invokes `st.ensure_min_topology("D1")`, indicating a minimum topology with a single device under test (DUT). The docstring also references "Test bed ID:4 D1--Mgmt network," reinforcing that only management connectivity is required. Additionally, fixtures reference `vars.D1` exclusively, and no neighbor devices or fabric links are exercised, implying a single-DUT setup.
+
+## 2. Overall Test Case Purpose
+- The test suite validates the SONiC device's NTP subsystem behavior within the SpyTest framework. It ensures that:
+  - NTP servers can be configured via Config DB and persist across service restarts.
+  - The NTP service remains operational through disable/enable cycles and maintains synchronization with configured servers.
+  - System log timestamps reflect correct time synchronization relative to system uptime.
+  - Existing NTP configurations are present when expected.
+- These checks confirm correct NTP protocol configuration, synchronization resilience, and logging accuracy on a SONiC DUT managed by SpyTest.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_ft_ntp_disable_enable_with_message_log`
+- **Intent & Logic**:
+  1. Ensures the minimal topology is available and initializes data such as log string, log retrieval depth, and current system time.
+  2. Sets the device clock manually and captures baseline log timestamps before NTP servers are added.
+  3. Calls the helper `config_ntp_server_on_config_db_file` to configure NTP servers via Config DB, save the configuration, verify the service is running, and confirm server reachability and synchronization.
+  4. Clears system logs, writes a custom log message, and parses the resulting log entry to confirm that timestamps align with expected clock values, proving that synchronization took effect.
+  5. Stops the NTP service to verify it can be disabled, then restarts it and ensures the service returns to an active state and re-synchronizes with servers.
+- **Importance**: Validates end-to-end NTP server provisioning, service resiliency, and log time correctness, which are critical for time-dependent networking features and troubleshooting accuracy.
+
+### `test_ntp_exists_config`
+- **Intent & Logic**: Invokes `ntp_obj.ensure_ntp_config(vars.D1)` to confirm that NTP configuration entries exist on the device. The test passes if the configuration is present and fails otherwise.
+- **Importance**: Provides a quick sanity check that base NTP settings are applied on the DUT, supporting the broader goal of validating NTP readiness.
+
+### Helper Function: `config_ntp_server_on_config_db_file`
+- **Role**: Centralizes the workflow for configuring NTP servers, updating system time, saving configuration, verifying service status, ensuring connectivity to each server via ping, and validating NTP synchronization state. This helper ensures consistent setup across tests and encapsulates repetitive operations.
+
+### Fixtures: `ntp_module_hooks` and `ntp_func_hooks`
+- **Role**: Autouse fixtures that initialize shared state (`vars`, `data`) before module and function execution. The module fixture obtains testbed variables, ensures global data structures are prepared, and cleans up NTP server configuration after all tests complete. The function-level fixture refreshes global data before each test to maintain consistency.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures**: `ntp_module_hooks`, `ntp_func_hooks` (autouse) manage setup/teardown and global state.
+- **Testbed Variables**: Require `vars.D1` representing the primary DUT; relies on a topology definition that supplies NTP server host parameters.
+- **SpyTest Utilities**: `st.ensure_min_topology`, `st.get_testbed_vars`, `st.poll_wait`, `st.report_fail`, `st.report_pass` for topology validation, data retrieval, polling, and result reporting.
+- **Service Requirements**: Accessible NTP servers defined in testbed data; ability to restart services (`basic_obj.service_operations`); Config DB access for NTP configuration; system logging enabled.
+- **Cleanup**: Module fixture removes NTP servers post-tests to prevent side effects on subsequent runs.
+
+## 5. Key Inputs and Parameters
+- `data.servers`: Derived via `utils_obj.ensure_service_params(vars.D1, "ntp", "host")`; represents the list of NTP server IPs/hosts to configure and validate against.
+- `data.ntp_service`: Hardcoded as `'ntp'`; specifies the systemd service name for service operations.
+- `data.time_date`: Current timestamp used to set the device clock before synchronization checks.
+- `data.string_generate`: Custom log message content for verifying syslog timestamps.
+- `data.lines`: Number of log lines retrieved for baseline clock parsing.
+- `iplist` parameter in `config_ntp_server_on_config_db_file`: List of NTP servers passed for configuration and verification.
+- Additional state (`vars.D1`) drawn from testbed definitions, controlling which DUT is targeted.
+
+## 6. External Libraries and Modules
+- `pytest`: Provides the testing framework, fixtures, and markers.
+- `time`: Used to capture formatted timestamps for clock configuration.
+- `spytest.st`: Core SpyTest API for logging, topology handling, polling, and reporting.
+- `SpyTestDict`: Utility for structured dictionary-like data storage across tests.
+- `apis.system.reboot`: Provides `config_save` for persisting Config DB changes.
+- `apis.system.ntp`: Supplies NTP-specific operations such as adding servers, verifying service status, configuring system time, and checking synchronization.
+- `apis.system.logging`: Interfaces with device syslog for showing, clearing, and writing log entries.
+- `apis.system.basic`: Used for generic service operations (start/stop/restart).
+- `utilities.utils`: Offers helper functions like `ensure_service_params` and `log_parser`.
+- `apis.routing.ip`: Contains the `ping` utility used to verify reachability of NTP servers.
+
+## 7. Unspecified Items
+- Exact NTP server IP addresses or hostnames: **Not specified** (sourced from external testbed data).
+- Precise testbed YAML structure or device inventory: **Not specified**.
+- Expected log message formats beyond what is parsed: **Not specified**.


### PR DESCRIPTION
## Summary
- add SpyTest analyzer documentation for the NTP system regression tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da1c4113048328b04468d4e196a3a6