### PR TITLE
Add analyzer documentation for sFlow system tests

### DIFF
--- a/docs/spytest_doc/system/test_sflow_analyzer.md
+++ b/docs/spytest_doc/system/test_sflow_analyzer.md
@@ -1,0 +1,58 @@
+# SpyTest Test Case Analyzer: `test_sflow.py`
+
+## 1. Topology Type
+- **Identified Topology:** Dual-DUT testbed with a single traffic generator host connected to both DUTs and an inter-DUT link ("D1T1:1", "D2T1:2", "D1D2:1").
+- **Inference Details:**
+  - The module-level fixture `sflow_module_hooks` invokes `st.ensure_min_topology("D1T1:1", "D2T1:2", "D1D2:1")`, which requires two DUTs (D1, D2) sharing at least one interconnect and multiple Test Generator (TG) ports.【F:spytest/tests/system/test_sflow.py†L52-L60】
+  - TG handles are fetched for `vars.T1D1P1`, `vars.T1D2P1`, and `vars.T1D2P2`, confirming a TGEN connected to both DUTs with three ports.【F:spytest/tests/system/test_sflow.py†L109-L131】
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate SONiC sFlow functionality, including sampling over IPv4/IPv6 collectors, maximum collector configuration combinations, and configuration persistence across save-and-reboot cycles.
+- **Context within SONiC/SpyTest:** These scenarios ensure that sFlow telemetry in SONiC operates correctly in dual-DUT deployments, integrates with TG-based traffic sampling, and maintains configuration durability, aligning with SpyTest's end-to-end system validation of telemetry features.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### 3.1 `test_ft_sflow_sampling_v6_sFlow_collector`
+- **Intent & Logic:**
+  - Reconfigures collectors to use IPv6 addresses and disables sFlow on an interface to test error conditions before re-enabling normal operations.【F:spytest/tests/system/test_sflow.py†L188-L234】
+  - Initiates traffic streams from the TG, captures sFlow samples, and validates packet contents against expected headers (agent ID and address type).【F:spytest/tests/system/test_sflow.py†L214-L252】
+  - Reviews psample statistics, collector interface counters, and sample counts to confirm adequate sampling, raising detailed diagnostics on failure.【F:spytest/tests/system/test_sflow.py†L252-L309】
+- **Contribution to Overall Goal:** Confirms functional sFlow sampling via IPv6 collectors, ensuring telemetry works across protocol versions.
+
+### 3.2 `test_ft_sflow_max_sflow_collector_config`
+- **Intent & Logic:**
+  - Exercises combinations of IPv4 and IPv6 collectors to ensure the platform honors the maximum supported collector count and validates configurations via `sflow.verify_config`.【F:spytest/tests/system/test_sflow.py†L311-L369】
+  - Sequentially tests mixed collectors, all-IPv6, and all-IPv4 setups, checking state, collector counts, and UDP port assignments after each change.【F:spytest/tests/system/test_sflow.py†L329-L368】
+- **Contribution to Overall Goal:** Verifies robustness of collector configuration handling and limit enforcement, critical for telemetry reliability.
+
+### 3.3 `test_ft_system_config_mgmt_verifying_config_with_save_reboot_sflow`
+- **Intent & Logic:**
+  - Issues `config_save` and device reboot, then confirms sFlow configuration persists post-reboot using `sflow.verify_config`.【F:spytest/tests/system/test_sflow.py†L371-L386】
+- **Contribution to Overall Goal:** Ensures sFlow settings survive management operations, validating configuration persistence.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `sflow_module_hooks` (module scope, autouse) handles topology validation, variable initialization, interface status checks, port speed collection, TG and sFlow setup/teardown.【F:spytest/tests/system/test_sflow.py†L52-L105】
+  - `sflow_func_hooks` (function scope, autouse) restores sFlow collector/sample configuration after specific tests and retains module state when required.【F:spytest/tests/system/test_sflow.py†L62-L84】
+- **Utilities/Helpers:**
+  - Traffic generator initialization via `tg_init` establishes TG interfaces and traffic streams.【F:spytest/tests/system/test_sflow.py†L109-L131】
+  - Routing configuration helpers (`config_routing_interfaces`, `sflow_module_prolog/epilog`) provision IP connectivity, collectors, and clean-up state.【F:spytest/tests/system/test_sflow.py†L86-L126】
+- **Topology Constraints:** Requires two DUTs, TG access to three ports, and support for port-channel operations and IPv4/IPv6 routing on D2.
+
+## 5. Key Inputs and Parameters
+- **`data` Dictionary:** Populated in `initialize_variables` with IP addresses, MACs, collector names, sampling rates, UDP ports, VRF names, and expected hex-encoded identifiers used for validations and TG configurations.【F:spytest/tests/system/test_sflow.py†L18-L51】
+- **Interface Speeds:** Captured per interface to adjust sampling rates when restoring configuration (`data.port_speed`).【F:spytest/tests/system/test_sflow.py†L60-L71】
+- **Traffic Stream Definitions:** TG configuration uses `data.ip4_addr`, `data.tg_mac*`, and derived DUT interface MAC addresses for generating test traffic.【F:spytest/tests/system/test_sflow.py†L114-L131】
+- **Collector Targets:** IPv4/IPv6 addresses from `data.ip4_addr` and `data.ip6_addr`, plus local host IPs, guide collector additions and verifications throughout the tests.【F:spytest/tests/system/test_sflow.py†L19-L51】【F:spytest/tests/system/test_sflow.py†L188-L369】
+
+## 6. External Libraries and Modules
+- **SpyTest Core:** `spytest.st`, `tgapi`, `SpyTestDict` for logging, topology management, traffic generator control, and shared state.【F:spytest/tests/system/test_sflow.py†L5-L18】
+- **Routing APIs:** `apis.routing.ip`, `apis.routing.arp` support interface addressing and route management, plus ARP table inspection.【F:spytest/tests/system/test_sflow.py†L7-L9】
+- **System APIs:** `apis.system.basic`, `apis.system.sflow`, `apis.system.logging`, `apis.system.interface`, `apis.system.reboot` provide interface status, sFlow configuration, log inspection, counter clearing, and reboot utilities.【F:spytest/tests/system/test_sflow.py†L9-L14】
+- **Switching APIs:** `apis.switching.portchannel`, `apis.switching.vlan` manage port-channel operations and reserved VLAN validation used in helper routines.【F:spytest/tests/system/test_sflow.py†L13-L15】【F:spytest/tests/system/test_sflow.py†L388-L399】
+- **Utilities:** `utilities.common`, `utilities.parallel`, `utilities.utils` supply data filtering, parallel execution, and value conversions required for verification logic.【F:spytest/tests/system/test_sflow.py†L15-L17】
+
+## 7. Unspecified Items
+- Specific references to `testbed.yaml`, `group_vars`, or CLI parameters are **Not specified** in this file.
+- Detailed hardware requirements (platform types, ASICs) are **Not specified**.
+- Reserved VLAN validation helper `reserved_vlan_verify` is defined but not invoked within these tests; its deployment context is **Not specified** beyond ensuring capability to manage reserved VLAN ranges.【F:spytest/tests/system/test_sflow.py†L388-L399】
+


### PR DESCRIPTION
## Summary
- add a SpyTest analyzer markdown file for the sFlow system test suite
- document topology, dependencies, and detailed subtest analysis for `test_sflow.py`

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68da1e9507ec832892056f27b9d6d1bd