### PR TITLE
Add analyzer documentation for ARP update test

### DIFF
--- a/docs/t0_topology_testplan/arp/test_arp_update_analyzer.md
+++ b/docs/t0_topology_testplan/arp/test_arp_update_analyzer.md
@@ -1,0 +1,53 @@
+# ARP Update Test Analyzer
+
+## 1. Topology Type
+- **Topology:** `t0`.
+- **Inference:** The module-level `pytestmark` applies `pytest.mark.topology("t0")`, explicitly scoping the test to the T0 topology profile used in SONiC regression beds. Additionally, conditional logic checks for `'dualtor'` within `tbinfo['topo']['name']`, indicating awareness of dual ToR variants of the T0 topology. 【F:tests/arp/test_arp_update.py†L15-L43】
+
+## 2. Overall Test Case Purpose
+- **High-level goal:** Validate the behavior of the `arp_update` supervisor service, ensuring that ARP/neighbor entries remain synchronized between the Linux kernel and SONiC's APPL_DB even after manual tampering.
+- **SONiC context:** In SONiC, the `arp_update` daemon monitors neighbor entries to keep control-plane databases consistent. This test stresses the daemon by intentionally corrupting the APPL_DB entry and expecting the daemon to reconcile state by removing the stale kernel neighbor entry. 【F:tests/arp/test_arp_update.py†L19-L73】
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_kernel_asic_mac_mismatch`
+- **Intent:** Exercise the `arp_update` daemon's ability to detect and correct MAC address mismatches between the kernel neighbor table and APPL_DB entries for both IPv4 and IPv6 neighbors.
+- **Logic:**
+  1. Uses fixtures to stop the `arp_update` process temporarily, flush kernel neighbors, and establish ARP responders on VLAN interfaces.
+  2. Chooses a target server IP (dual ToR aware) and sends a ping to ensure the neighbor is learned in the kernel.
+  3. Waits until the neighbor entry is both present in the kernel and synchronized in APPL_DB.
+  4. Manually overwrites the APPL_DB neighbor MAC with an all-zero value, creating an intentional mismatch.
+  5. Restarts the `arp_update` service, expecting it to notice the mismatch and purge the kernel neighbor entry, validating proper cleanup.
+- **Importance:** Confirms that `arp_update` prevents stale or poisoned neighbor entries, which is critical for maintaining correct forwarding behavior in the T0 topology with dual ToR scenarios. Parameterization over IPv4 and IPv6 ensures coverage across protocol families. 【F:tests/arp/test_arp_update.py†L31-L73】
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `setup` (local fixture) stops `arp_update` and flushes neighbors before the test, then restarts the service afterward. 【F:tests/arp/test_arp_update.py†L19-L31】
+  - `setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally`: prepares ToR/standby ports for the dual ToR test scenario.
+  - `toggle_all_simulator_ports_to_rand_selected_tor`: ensures the mux simulator aligns traffic toward the randomly selected DUT in dual ToR setups. 【F:tests/arp/test_arp_update.py†L7-L8】
+  - `rand_selected_dut`: supplies a randomly chosen DUT object for command execution.
+  - `setup_vlan_arp_responder`: configures PTF host ARP responders for VLAN testing and provides addressing details. 【F:tests/arp/test_arp_update.py†L8-L43】
+  - `tbinfo`: conveys topology metadata used to distinguish standard T0 from dual ToR topologies. 【F:tests/arp/test_arp_update.py†L43-L51】
+- **Topology constraints:** Requires a T0 or dual ToR T0 testbed with mux simulator support so the test can toggle ToR states and reach server IPs.
+- **Process control:** Ability to manage `swss` container services (`supervisorctl`) and access SONiC databases.
+
+## 5. Key Inputs and Parameters
+- `ip_version`: PyTest parameter (4 or 6) selecting IPv4 or IPv6 execution path. 【F:tests/arp/test_arp_update.py†L37-L45】
+- `setup_vlan_arp_responder` return values (`vlan_name`, `ipv4_base`, `ipv6_base`, `ip_offset`): define VLAN interface names and target IPs used for neighbor learning. 【F:tests/arp/test_arp_update.py†L43-L57】
+- `tbinfo['topo']['name']`: determines whether dual ToR handling is required for server IP selection. 【F:tests/arp/test_arp_update.py†L45-L51】
+- `mux_cable_server_ip(rand_selected_dut)`: supplies per-interface server IP assignments in dual ToR environments, influencing the neighbor target. 【F:tests/arp/test_arp_update.py†L11-L51】
+- Shell commands (e.g., `ip neigh`, `sonic-db-cli`, `ping`, `supervisorctl`): control kernel and database state to orchestrate the mismatch scenario. 【F:tests/arp/test_arp_update.py†L22-L73】
+
+## 6. External Libraries and Modules
+- **Standard libraries:**
+  - `logging`: provides structured logging within the test for debugging and traceability. 【F:tests/arp/test_arp_update.py†L3-L14】
+  - `random`: selects a random server interface in dual ToR cases. 【F:tests/arp/test_arp_update.py†L5-L51】
+- **PyTest:** Used for fixtures, parametrization, and assertions (via `pt_assert`). 【F:tests/arp/test_arp_update.py†L4-L69】
+- **SONiC test helpers:**
+  - `tests.common.dualtor.mux_simulator_control.toggle_all_simulator_ports_to_rand_selected_tor`: orchestrates mux simulator state for dual ToR validation. 【F:tests/arp/test_arp_update.py†L7-L51】
+  - `tests.common.fixtures.ptfhost_utils.setup_vlan_arp_responder`: fixture enabling VLAN ARP responses from the PTF host. 【F:tests/arp/test_arp_update.py†L8-L57】
+  - `tests.common.helpers.assertions.pytest_assert`: SONiC-specific assert wrapper for consistent error messaging. 【F:tests/arp/test_arp_update.py†L9-L71】
+  - `tests.common.utilities.wait_until`: polling helper to wait for neighbor learning and synchronization. 【F:tests/arp/test_arp_update.py†L10-L70】
+  - `tests.common.dualtor.dual_tor_utils.mux_cable_server_ip`: retrieves server IP mappings in dual ToR setups. 【F:tests/arp/test_arp_update.py†L11-L51】
+
+## 7. Unspecified Items
+- Additional environment variables, inventory specifics, or CLI overrides influencing the test are **not specified** within this test file.


### PR DESCRIPTION
## Summary
- add a topology test analyzer markdown file documenting the ARP update pytest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da26bae074832f9f44a3156217436f