### PR TITLE
Add analyzer for unknown MAC ARP test

### DIFF
--- a/docs/t0_topology_testplan/arp/test_unknown_mac_analyzer.md
+++ b/docs/t0_topology_testplan/arp/test_unknown_mac_analyzer.md
@@ -1,0 +1,56 @@
+# Test Analysis: `tests/arp/test_unknown_mac.py`
+
+## 1. Topology Type
+- **Topology:** `t0` topology.
+- **Inference:** The module-wide `pytestmark = [pytest.mark.topology("t0")]` decorator explicitly constrains the test to run on T0 environments. Additional evidence comes from the VLAN and port-channel assumptions pulled from minigraph facts (typical for T0). 
+
+## 2. Overall Test Case Purpose
+- **Goal:** Validate that the device under test (DUT) drops traffic destined to an IP whose ARP entry exists but whose MAC is not learned in the forwarding database (FDB), across multiple DSCP priorities.
+- **Context in SONiC framework:** Ensures SONiC correctly handles unknown destination MAC behavior after ARP resolution—critical for broadcast domain isolation and lossless/lossy queue handling. This aligns with verification of Layer 2/Layer 3 interaction and flooding suppression within the SONiC dataplane.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `TestUnknownMac.test_unknown_mac`
+- **Intent & Logic:**
+  - Parameterized over DSCP values (`dscp-3`, `dscp-4`, `dscp-8`) to cover both lossy and lossless priorities.
+  - Leverages `unknownMacSetup` to gather VLAN, interface, and PTF mapping details; `populateArp` prepares a valid ARP entry without corresponding FDB entries.
+  - Invokes `validateEntries()` (instantiating `PreTestVerify`) to confirm ARP presence and FDB absence, flushing FDB entries to enforce unknown MAC state.
+  - Runs `TrafficSendVerify.runTest()` to send traffic from every relevant PTF interface towards the DUT. The helper verifies:
+    - Drop counters increment on the egress interfaces.
+    - No packet is forwarded back to PTF VLAN ports, ensuring drop behavior.
+- **Relevance:** Demonstrates the DUT’s adherence to expected unknown-MAC handling across QoS classes, preventing unintended flooding even when ARP is populated.
+
+### Helper Classes & Fixtures
+- **`PreTestVerify` class:** Confirms ARP entries exist, flushes MAC table, and checks the target MAC is absent post-flush; provides ARP-to-MAC mapping for later validation. Critical for establishing the test preconditions.
+- **`TrafficSendVerify` class:** Constructs UDP packets per interface, captures pre-test drop counters, sends traffic, and ensures drops occur with counter increments. Validates dataplane behavior under unknown MAC conditions.
+- **`populateArp` fixture:** Auto-used to configure PTF interfaces, trigger ARP population via ping, and clean up addresses. Ensures the DUT has ARP resolution prior to test execution.
+- **`flushArpFdb` fixture:** Clears ARP and FDB entries before and after tests, guaranteeing consistent starting state.
+- **`unknownMacSetup` fixture:** Gathers topology facts, selects destination VLAN ports, and builds mapping of DUT interfaces to PTF counterparts, supporting both standard T0 and backend/dualtor variants.
+- **`dut_disable_arp_update` fixture:** Temporarily stops the `arp_update` service to avoid background MAC learning that could interfere with unknown-MAC verification.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:** `duthosts`, `rand_one_dut_hostname`, `rand_selected_dut`, `ptfhost`, `ptfadapter`, `tbinfo`, dual ToR toggling fixtures, `iptables_drop_ipv6_tx`, and autouse fixtures described above.
+- **Topology Constraints:** Requires a T0 topology with VLANs, PTF connectivity to VLAN/member ports, and (optionally) backend or dualtor variants supported by `unknownMacSetup` logic.
+- **Platform Limitations:** Skips Mellanox and Barefoot ASICs due to differing unknown MAC behavior.
+- **Services:** Needs ability to control `arp_update` within the `swss` container and issue `sonic-clear` commands; assumes access rights via Ansible host wrappers.
+
+## 5. Key Inputs and Parameters
+- **Minigraph/VLAN facts:** Pulled via `get_extended_minigraph_facts` to determine VLAN IP, prefix, members, port-channel interfaces, and PTF port indices.
+- **`TEST_PKT_CNT` (10):** Number of packets sent per interface to validate drop counters.
+- **DSCP values (`dscp-3`, `dscp-4`, `dscp-8`):** Influence the IP ToS field to exercise both lossy and lossless queues.
+- **Generated IP assignments:** `duthost.get_ip_in_range` supplies host IPs for PTF interfaces to craft traffic sources.
+- **DualToR server IPs:** `mux_cable_server_ip` used to exclude specific IPs when selecting generated addresses.
+- **Command outputs:** `show arp`, `ip neigh show`, `show mac`, and `portstat -j` provide validation data for ARP/FDB state and counters.
+
+## 6. External Libraries and Modules
+- **Standard Libraries:** `functools`, `inspect`, `json`, `logging`, `random`, `re`, `time` for utility operations, reflection, parsing, logging, and delays.
+- **Pytest (`pytest`):** Provides fixture management, parameterization, and assertions (`pytest.mark`, `pytest.fixture`).
+- **PTF (`ptf.testutils`, `ptf.mask`, `ptf.packet`):** Builds and sends packets, masks checksum fields, and verifies absence of packets on PTF ports.
+- **SONiC Test Helpers:**
+  - `tests.common.constants`, `tests.common.utilities.get_intf_by_sub_intf`, `wait_until` for topology constants and helper routines.
+  - Fixtures from `tests.common.fixtures.ptfhost_utils` to manage PTF host MAC addresses, copy ARP responder scripts, and block IPv6 transmissions.
+  - `tests.common.helpers.assertions` (`pytest_assert`, `pytest_require`) for enhanced assertion messaging.
+  - Dual ToR utilities (`mux_cable_server_ip`, `toggle_all_simulator_ports_to_rand_selected_tor_m`) to handle dual-homing specifics.
+
+## 7. Unspecified Items
+- Detailed definitions of external fixtures such as `toggle_all_simulator_ports_to_rand_selected_tor_m`, `setup_standby_ports_on_rand_unselected_tor_unconditionally`, and `iptables_drop_ipv6_tx` are **Not specified** within this file.
+- Explicit references to testbed inventory variables beyond minigraph-derived data are **Not specified**.


### PR DESCRIPTION
## Summary
- document the t0 unknown MAC ARP pytest in docs/t0_topology_testplan/arp
- outline topology, setup fixtures, test steps, and dependencies for TestUnknownMac

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da287f6314832fa11a200e1653e629