### PR TITLE
Add analysis documentation for warm reboot ARP test

### DIFF
--- a/docs/t0_topology_testplan/arp/test_wr_arp_analyzer.md
+++ b/docs/t0_topology_testplan/arp/test_wr_arp_analyzer.md
@@ -1,0 +1,58 @@
+# Warm Reboot ARP QA Analysis
+
+## 1. Topology Type
+* **Topology:** `t0` topology.
+* **Inference:** The module-level `pytestmark` includes `pytest.mark.topology('t0')`, which indicates that the testbed definition and fixtures must supply a single SONiC DUT connected to a fanout/ToR-style leaf-spine fabric with server-facing VLANs typical of the `t0` topology. No alternative topology markers are present in the file.
+
+## 2. Overall Test Case Purpose
+* **Goal:** Validate ARP resiliency and control-plane assist behavior during SONiC warm reboot.
+* **Context:** These tests leverage the Ferret control-plane assistant service and PTF infrastructure to ensure that ARP requests from the PTF host continue to receive timely responses while the DUT performs a warm reboot. The verification aligns with SONiC warm reboot guarantees—minimizing control-plane disruption and preserving L2 reachability for VLAN members during reboot sequences.
+
+## 3. Detailed Breakdown of Sub-Testcases
+
+### `test_wr_arp`
+* **Intent & Logic:**
+  * Invokes the shared helper `testWrArp` to run the baseline warm reboot ARP validation flow.
+  * The helper starts the Ferret server, initiates warm reboot on the DUT, and continually probes ARP request/response behavior from all VLAN member ports, failing if any port lacks replies for more than 25 seconds.
+* **Relevance:** Confirms that the standard warm reboot control-plane assist mechanism maintains ARP connectivity, establishing the core functionality under test.
+
+### `test_wr_arp_advance`
+* **Intent & Logic:**
+  * Derives runtime parameters from pytest options and host inventory (e.g., `--test_duration`, DUT/PTF management IPs, and alternate credentials).
+  * Calls `ptf_runner` to execute the advanced Ferret-based scenario `wr_arp.ArpTest` on the PTF in Python 3 mode with `advance=True` and the VXLAN-specific configuration file.
+  * Logs results to `/tmp/wr_arp.ArpTest.Advance.log` for debugging.
+* **Relevance:** Extends coverage by running the more feature-rich “advanced” ARP warm reboot scenario, stressing additional control-plane assist paths (such as VXLAN overlays) to ensure robustness under extended durations and alternate credentials.
+
+### Helper Fixtures and Functions
+* **`setupFerretFixture` (autouse, class scope):** Ensures the Ferret server is configured on the DUT/PTF before tests run.
+* **`setupRouteToPtfhostFixture` (autouse, class scope):** Adds a temporary route from the DUT to the PTF host and removes it after tests.
+* **`clean_dut` (autouse, class scope):** Clears the DUT ARP cache post-test to restore baseline state.
+* **`warmRebootSystemFlag` (autouse, class scope):** Waits for the warm-reboot enable flag to reset to `false`; if not, it explicitly resets the flag, preventing residue configuration from affecting other suites.
+* **`checkWarmbootFlag`:** Helper used by `warmRebootSystemFlag` to query STATE_DB for the current warm reboot setting.
+
+These fixtures create the environmental prerequisites (Ferret setup, routing, cache hygiene, and warm reboot flag control) necessary for both test cases to run reliably.
+
+## 4. Dependencies and Prerequisites
+* **Fixtures:** `duthosts`, `rand_one_dut_hostname`, `ptfhost`, `tbinfo`, `creds` are required to access the DUT/PTF inventory and credentials. Autouse fixtures handle Ferret setup, route configuration, ARP cache cleanup, and warm reboot flag management.
+* **Topology Constraints:** Designed for a single-DUT `t0` testbed with VLAN member ports accessible from the PTF host.
+* **External Tools:** Requires Ferret control-plane assistant binaries/scripts on the DUT/PTF and access to the PTF `ptftests` package.
+
+## 5. Key Inputs and Parameters
+* `--test_duration` pytest CLI option (default `DEFAULT_TEST_DURATION`): controls how long the advanced test runs ARP probes.
+* `PTFRUNNER_QLEN`: defines packet queue length for the PTF runner execution.
+* `VXLAN_CONFIG_FILE`: configuration file passed to the advanced test to enable VXLAN-specific validation.
+* Credentials from the `creds` fixture (`sonicadmin_user`, `sonicadmin_password`) and alternate password retrieved from inventory hostvars: allow the PTF to SSH into the DUT during the Ferret-assisted scenario.
+* Management IPs for the DUT/PTF pulled from the Ansible inventory: provide connectivity endpoints for Ferret and PTF runner commands.
+
+## 6. External Libraries and Modules
+* **`logging`:** Provides structured logging for diagnostic messages.
+* **`pytest`:** Supplies the testing framework, fixture management, and topology markers.
+* **`tests.common.fixtures.ptfhost_utils` helpers:** Prepare the PTF environment by copying ptftests, adjusting MAC addresses, and cleaning IP configuration (marked as imports though not invoked directly here; autouse fixtures from the shared module may leverage them).
+* **`tests.common.storage_backend.backend_utils.skip_test_module_over_backend_topologies`:** Enables conditional skipping when running against unsupported storage backend topologies (imported for potential autouse fixture side effects).
+* **`tests.ptf_runner.ptf_runner`:** Executes PTF test scripts remotely on the PTF host.
+* **`tests.common.utilities.wait_until`:** Polling utility used to wait for the warm reboot flag to reset.
+* **`tests.common.arp_utils` helpers (`setupFerret`, `teardownRouteToPtfhost`, `setupRouteToPtfhost`, `PTFRUNNER_QLEN`, `VXLAN_CONFIG_FILE`, `DEFAULT_TEST_DURATION`, `testWrArp`):** Provide Ferret setup/teardown, routing utilities, configuration constants, and the shared warm reboot ARP test implementation.
+
+## 7. Unspecified Items
+* Details on Ferret implementation internals, precise VLAN membership, and the content of `VXLAN_CONFIG_FILE` are **Not specified** within this test file.
+* Specific pass/fail thresholds beyond the 25-second ARP response timeout enforced by `testWrArp` are **Not specified** here.


### PR DESCRIPTION
## Summary
- add a QA analysis document for the warm reboot ARP pytest suite under the t0 topology test plan

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da288c23fc832fb5e2527451f724f6