### PR TITLE
Add analyzer documentation for BGP neighbor route learning test

### DIFF
--- a/docs/t0_topology_testplan/bgp/test_bgp_route_neigh_learning_analyzer.md
+++ b/docs/t0_topology_testplan/bgp/test_bgp_route_neigh_learning_analyzer.md
@@ -1,0 +1,51 @@
+# BGP Neighbor Route Learning Test Analyzer
+
+## 1. Topology Type
+- **Topology:** `t0`.
+- **Inference:** The module-level `pytestmark` declares `pytest.mark.topology('t0')`, indicating the testbed must instantiate a T0 topology with both front-end DUT(s) and T1 neighbors. The fixtures `nbrhosts` and `enum_frontend_dut_hostname` further confirm that the environment provides neighbor hosts and selects the active frontend DUT typical of a T0 setup.
+
+## 2. Overall Test Case Purpose
+- **Goal:** Validate that a SONiC DUT in a T0 topology properly learns IPv4 routes advertised by its T1 BGP neighbors.
+- **Context:** Within the SONiC PyTest framework, this ensures BGP control-plane functionality—specifically that routes injected on neighbor devices propagate into the DUT’s Redis route table (ASIC DB) and that the DUT’s BGP configuration remains responsive to dynamic updates.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_bgp_neighbor_route_learnning`
+- **Intent & Flow:**
+  1. Leverages the `setUp` fixture to discover two T1 neighbors, obtain their BGP AS numbers, and prepare cleanup logic.
+  2. Calls `run_bgp_neighbor_route_learning` which, for each selected T1 neighbor:
+     - Configures Loopback1 with the target prefix (`77.88.99.1/32`).
+     - Injects the prefix into the neighbor’s BGP process (handling both EOS and SONiC neighbor types).
+  3. Polls the DUT’s Redis route table (`ROUTE_TABLE`) via `redis-cli` to ensure the new prefix appears with nexthops matching the number of advertising neighbors.
+  4. Asserts that the route is learned within the timeout window.
+- **Importance:** Confirms the DUT’s BGP control plane learns and installs routes from multiple neighbors, a foundational requirement for T0 fabric correctness.
+
+### Helper Components
+- **`setUp` fixture:** Gathers neighbor metadata, limits the scope to two T1 neighbors, and guarantees teardown by withdrawing the test prefix and removing the loopback interface from each neighbor.
+- **`run_bgp_neighbor_route_learning` function:** Encapsulates the operational steps for configuring neighbors and verifying route propagation, enabling reuse if additional tests are later added.
+- **`_check_route_propagation` helper:** Polls the DUT to confirm the prefix appears with the expected number of nexthops, serving as the predicate for `wait_until`.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `nbrhosts` supplies the neighbor host objects used to program routes.
+  - `duthosts` gives access to the SONiC DUT hosts for executing commands.
+  - `enum_frontend_dut_hostname` selects the target DUT in multi-DUT topologies.
+  - Module-scoped `setUp` fixture orchestrates preparation and cleanup.
+- **Topology Constraints:** Requires a T0 topology with at least two T1 neighbors reachable from the DUT.
+- **Utilities:** Uses `wait_until` for polling and `pytest_assert` for consistent assertion handling.
+
+## 5. Key Inputs and Parameters
+- **`V4_PREFIX` / `V4_MASK`:** Hard-coded to `77.88.99.1/32`; the prefix injected on neighbors and expected on the DUT.
+- **BGP AS Numbers:** Discovered dynamically from `show ip bgp summary json` on the DUT to ensure neighbor configuration matches current AS assignments.
+- **Timeout Parameters:** `wait_until(10, 2, 0, ...)` enforces a 10-second observation window with 2-second intervals when checking route propagation.
+
+## 6. External Libraries and Modules
+- **`json`:** Parses BGP summary output from the DUT.
+- **`pytest`:** Provides the testing framework, fixtures, and markers.
+- **`logging`:** Records debug and cleanup information.
+- **`tests.common.helpers.assertions.pytest_assert`:** Offers uniform assertion messaging.
+- **`tests.common.devices.eos.EosHost` / `tests.common.devices.sonic.SonicHost`:** Device abstraction layers used to run neighbor configuration commands based on platform type.
+- **`tests.common.utilities.wait_until`:** Utility to poll for state changes with timeout handling.
+
+## 7. Unspecified Items
+- Test-specific inventory details (e.g., exact neighbor hostnames or IPs) – **Not specified**.
+- Any non-default configuration parameters beyond those listed – **Not specified**.


### PR DESCRIPTION
## Summary
- add documentation analyzer covering the BGP neighbor route learning pytest for the t0 topology test plan

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68da29b00948832f8c43ba9ca8aa9a5d