### PR TITLE
Add analyzer documentation for BGP speaker tests

### DIFF
--- a/docs/t0_topology_testplan/bgp/test_bgp_speaker_analyzer.md
+++ b/docs/t0_topology_testplan/bgp/test_bgp_speaker_analyzer.md
@@ -1,0 +1,47 @@
+# Test Case Analysis: `tests/bgp/test_bgp_speaker.py`
+
+## 1. Topology type
+- The module is explicitly marked to run on the T0 topology via `pytest.mark.topology('t0')`, targeting virtual switch (VS) devices.【F:tests/bgp/test_bgp_speaker.py†L23-L26】
+- An autouse fixture skips the suite when the topology name contains `dualtor`, indicating the tests expect a single-TOR T0 setup rather than dual-homing variants.【F:tests/bgp/test_bgp_speaker.py†L69-L73】
+- The common setup fixture pulls minigraph facts, VLAN membership, and configures VLAN-based PTF ports, aligning with the fanout-host connectivity typical of T0 labs.【F:tests/bgp/test_bgp_speaker.py†L85-L188】
+
+## 2. Overall test case purpose
+- The suite validates SONiC's dynamic BGP speaker behavior on a T0 topology by ensuring external ExaBGP speakers can establish sessions, advertise routes, and trigger correct FIB programming and flow counters on the DUT.【F:tests/bgp/test_bgp_speaker.py†L205-L416】
+- Within the SONiC pytest framework, it exercises control-plane neighbor bring-up (`bgp_facts`), data-plane route acceptance (`get_ip_route_info`), and forwarding verification through PTF FIB tests and optional flow counter checks, providing confidence in end-to-end BGP speaker interoperability.【F:tests/bgp/test_bgp_speaker.py†L217-L383】
+
+## 3. Detailed breakdown of sub-testcases
+### `test_bgp_speaker_bgp_sessions`
+- Reuses the shared setup, waits for ExaBGP HTTP readiness, pauses for convergence, then asserts every BGP neighbor is in `established` state and specifically checks the speaker IP learned from the PTF host.【F:tests/bgp/test_bgp_speaker.py†L205-L230】
+- This subtest confirms control-plane adjacency formation, which is prerequisite for any subsequent route announcements and validates the dynamic BGP neighbor configuration on the DUT.
+
+### `test_bgp_speaker_announce_routes`
+- Parameterized for IPv4 reachability, it passes IPv4-enabled flags to the common route advertisement helper. The helper advertises IPv4 prefixes from PTF ExaBGP instances, waits until all dynamic neighbors report accepted prefixes, inspects route next-hops/interfaces, builds a route-port map, and runs the PTF `fib_test` to verify traffic forwarding and optional flow counter increments before withdrawing the routes.【F:tests/bgp/test_bgp_speaker.py†L279-L390】【F:tests/bgp/test_bgp_speaker.py†L393-L403】
+- Validates that IPv4 routes learned from dynamic speakers are correctly installed and forwarded, exercising both control-plane acceptance and data-plane egress selection.
+
+### `test_bgp_speaker_announce_routes_v6`
+- Mirrors the IPv4 test but with IPv6 flags and prefixes, leveraging IPv6 nexthops prepared during setup. It ensures IPv6 dynamic routes are accepted, programmed, and successfully forwarded through the DUT.【F:tests/bgp/test_bgp_speaker.py†L279-L390】【F:tests/bgp/test_bgp_speaker.py†L406-L416】
+- Extends coverage to IPv6, confirming parity of BGP speaker functionality across protocol families.
+
+### Helper functions and fixtures
+- `generate_ips`, `announce_route`, `withdraw_route`, and `change_route` create address pools and drive ExaBGP HTTP APIs to manage route advertisements from the PTF host.【F:tests/bgp/test_bgp_speaker.py†L32-L67】
+- `is_all_neighbors_learned` encapsulates the convergence check on dynamic neighbors' accepted prefixes.【F:tests/bgp/test_bgp_speaker.py†L269-L276】
+- Fixtures such as `common_setup_teardown`, `vlan_mac`, and topology-aware helpers (`get_dut_enabled_ptf_ports`, `get_dut_vlan_ptf_ports`) provision the DUT/PTF environment, handle dual-TOR nuances, and ensure PTF tests are parameterized with accurate port and MAC data.【F:tests/bgp/test_bgp_speaker.py†L75-L200】【F:tests/bgp/test_bgp_speaker.py†L233-L366】
+
+## 4. Dependencies and prerequisites
+- Fixtures: `skip_dualtor`, `common_setup_teardown`, `vlan_mac`, and topology helpers require DUT handles, PTF host access, localhost control, and topology info, collectively preparing ExaBGP instances, VLAN interfaces, and cleanup hooks.【F:tests/bgp/test_bgp_speaker.py†L69-L200】【F:tests/bgp/test_bgp_speaker.py†L233-L366】
+- Environment: Access to minigraph facts, VLAN configuration, and deployment ASN mapping via `sonic-cfggen` is required to derive speaker ASNs and network ranges.【F:tests/bgp/test_bgp_speaker.py†L85-L175】
+- PTF infrastructure: The tests assume the PTF host can run ExaBGP, configure interfaces, and execute `fib_test` with generated route-port mappings.【F:tests/bgp/test_bgp_speaker.py†L142-L383】
+
+## 5. Key inputs and parameters
+- Generated speaker and VLAN IP pools supply neighbors and nexthops for ExaBGP sessions and route advertisements.【F:tests/bgp/test_bgp_speaker.py†L97-L148】
+- `port_num` defines unique ExaBGP HTTP control ports for each speaker instance, ensuring management connectivity.【F:tests/bgp/test_bgp_speaker.py†L110-L183】
+- Route prefixes `10.10.10.0/26` and `fc00:10::/64`, MTU parameter `9114`, and IPv4/IPv6 enable flags drive the test scenarios within the parameterized test cases.【F:tests/bgp/test_bgp_speaker.py†L279-L416】
+- Minigraph-derived data (loopback address, peer ranges, VLAN membership, port indices) inform route announcements, expected next-hops, and PTF template rendering.【F:tests/bgp/test_bgp_speaker.py†L112-L344】
+
+## 6. External libraries and modules
+- Standard/third-party imports: `pytest`, `netaddr`, `time`, `logging`, `requests`, `ipaddress`, and `json` provide testing framework capabilities, IP manipulation, HTTP interactions, and serialization.【F:tests/bgp/test_bgp_speaker.py†L1-L7】
+- SONiC pytest helpers: modules from `tests.common` supply constants, PTF fixtures, TCP wait utilities, assertion helpers, polling utilities, flow counter context, and DUT port helpers, facilitating environment setup and verification steps.【F:tests/bgp/test_bgp_speaker.py†L9-L20】【F:tests/bgp/test_bgp_speaker.py†L335-L383】
+- `tests.ptf_runner.ptf_runner` launches PTF-based functional tests validating data-plane behavior.【F:tests/bgp/test_bgp_speaker.py†L14】【F:tests/bgp/test_bgp_speaker.py†L369-L383】
+
+## 7. Unspecified items
+- Any additional testbed-specific variables beyond those retrieved from minigraph facts (e.g., explicit `testbed.yaml` samples) are not specified in this file.


### PR DESCRIPTION
## Summary
- add a QA analysis document for `tests/bgp/test_bgp_speaker.py` covering topology, dependencies, and subtest intent

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68da29d86b04832f9879b28faa708ac4