### PR TITLE
Add analyzer for active ToR downstream orchagent tests

### DIFF
--- a/docs/t0_topology_testplan/dualtor/test_orchagent_active_tor_downstream_analyzer.md
+++ b/docs/t0_topology_testplan/dualtor/test_orchagent_active_tor_downstream_analyzer.md
@@ -1,0 +1,54 @@
+# Test Analyzer: `tests/dualtor/test_orchagent_active_tor_downstream.py`
+
+## 1. Topology Type
+- **Declared Topology:** `t0` dual ToR topology, as marked by `pytestmark = [pytest.mark.topology('t0'), ...]` in the test file.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L23-L31】
+- **Inference Explanation:** The explicit `pytest.mark.topology('t0')` annotation indicates the testbed leverages the T0 dual ToR setup. Additional fixtures such as `apply_mock_dual_tor_tables` and use of `dualtor_info` confirm the dual ToR environment expected by these tests.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L8-L19】【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L23-L31】
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate downstream traffic handling and neighbor/ECMP resiliency on the active ToR within a dual ToR deployment.
+- **Context in SONiC Automation:** These tests exercise orchagent behavior when serving downstream traffic to servers under active/standby mux transitions and neighbor entry changes, ensuring traffic forwarding aligns with dual ToR design expectations and that state transitions maintain correctness.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L53-L135】【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L137-L187】
+
+## 3. Detailed Breakdown of Sub-Testcases
+
+### `test_active_tor_remove_neighbor_downstream_active`
+- **Intent & Logic:**
+  - Builds traffic toward a server via the active ToR using packets crafted through `build_packet_to_server` and sends them from a randomly selected T1 interface.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L71-L99】
+  - Uses `ServerTrafficMonitor` and `tunnel_traffic_monitor` to confirm traffic reaches the server without unintended tunnel forwarding while the neighbor entry exists.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L93-L111】
+  - Temporarily removes the server neighbor entry via the nested `remove_neighbor` context manager, verifying traffic drops and no tunnel traffic flows, then checks neighbor reachability restoration using `wait_until` and `neighbor_reachable`.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L57-L135】
+  - Restores traffic verification after neighbor recovery to ensure orchagent resumes direct forwarding.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L121-L135】
+- **Relevance:** Ensures orchagent correctly handles neighbor state removal/recovery scenarios on the active ToR, a critical behavior for maintaining data plane integrity in dual ToR environments.
+- **Supporting Helpers:**
+  - `ip_version` fixture parameterizes IPv4/IPv6 paths.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L33-L37】
+  - `testbed_setup` fixture configures server addressing and responders per IP version.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L40-L53】
+  - `neighbor_reachable` helper reads the ARP/ND table to determine neighbor state.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L56-L63】
+  - Inline `remove_neighbor` context manager handles neighbor flushing and service restarts.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L73-L88】
+
+### `test_downstream_ecmp_nexthops`
+- **Intent & Logic:**
+  - Sets all mux interfaces to active and retrieves interface-to-server mappings for four nexthops.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L139-L151】
+  - Adds a static route with multiple nexthops targeting the downstream servers, then verifies traffic only egresses via a single active downlink/uplink using `check_nexthops_single_downlink`.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L152-L164】
+  - Sequentially transitions each mux to standby, confirming ECMP behavior adapts to available downlinks, and finally reactivates interfaces to validate recovery logic.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L166-L183】
+  - Cleans up by removing static routes.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L184-L187】
+- **Relevance:** Validates ECMP route management and mux state transitions keep downstream forwarding consistent, ensuring orchagent only selects viable downlinks in dual ToR redundancy scenarios.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - Module-level fixtures: `apply_mock_dual_tor_tables`, `apply_mock_dual_tor_kernel_configs`, `apply_active_state_to_orchagent`, `run_garp_service`, `run_icmp_responder` prepare the dual ToR environment with mock tables, kernel configs, active state, and background responder services.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L23-L31】
+  - Test-specific fixtures include `ptfadapter`, `ptfhost`, `rand_selected_dut`, `rand_unselected_dut`, `tbinfo`, `conn_graph_facts`, `set_crm_polling_interval`, `tunnel_traffic_monitor`, `vmhost`, `toggle_all_simulator_ports`, and `tor_mux_intfs`. These provide DUT handles, topology metadata, CRM monitoring, mux controls, and traffic monitors necessary to exercise and observe behaviors.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L40-L190】
+- **Topology Constraints:** Requires a dual ToR-capable T0 testbed with mux simulator support to toggle port states and observe downstream traffic paths. (Implied from `dualtor` utilities and mux state manipulations).【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L9-L19】【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L139-L183】
+
+## 5. Key Inputs and Parameters
+- **`ip_version` Fixture:** Determines whether tests run using IPv4 or IPv6 addresses, altering server IP selection and ARP/ND responder setup.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L33-L53】
+- **Server and Interface Mapping:** `dualtor_info` and `get_interface_server_map` supply target server IPs and interface mappings for routing and traffic verification.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L40-L52】【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L139-L155】
+- **`nexthops_count` and `dst_server_addr`:** Control the number of mux interfaces participating in ECMP and the destination prefix installed for forwarding checks.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L138-L154】
+- **MUX State Toggles:** `set_mux_state` leverages `toggle_all_simulator_ports` and `tor_mux_intfs` to manipulate mux states, shaping the forwarding topology under test.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L137-L183】
+
+## 6. External Libraries and Modules
+- **Standard Libraries:** `contextlib`, `logging`, `random`, and `ipaddress.ip_address` support context management, logging, random port selection, and IP version detection.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L1-L7】
+- **PyTest:** Provides fixtures, parametrization, and test structure (`pytest`, `pytest.mark`).【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L2-L36】
+- **PTF TestUtils:** `ptf.testutils` enables packet crafting and transmission from the PTF host.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L7-L99】
+- **SONiC Test Common Modules:** Numerous helpers from `tests.common.dualtor` and `tests.common.fixtures` support dual ToR information gathering, neighbor manipulation, mux control, traffic monitoring, and fixture utilities essential to orchestrating the scenarios.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L8-L22】
+- **Assertions & Utilities:** `tests.common.helpers.assertions.pytest_assert` and `tests.common.utilities.wait_until` provide assertion helpers and polling mechanisms for neighbor state recovery.【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L21-L22】【F:tests/dualtor/test_orchagent_active_tor_downstream.py†L117-L120】
+
+## 7. Unspecified Items
+- Additional configuration sources (e.g., specific `testbed.yaml` entries, inventory variables, or CLI parameters) are **Not specified** within the test file.


### PR DESCRIPTION
## Summary
- add documentation analyzer covering dual ToR orchagent downstream tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da37008f00832f9905ab51deda5520