### PR TITLE
Add analyzer for standby ToR upstream mux toggle test

### DIFF
--- a/docs/t0_topology_testplan/dualtor/test_standby_tor_upstream_mux_toggle_analyzer.md
+++ b/docs/t0_topology_testplan/dualtor/test_standby_tor_upstream_mux_toggle_analyzer.md
@@ -1,0 +1,54 @@
+# Test Case Analyzer: `tests/dualtor/test_standby_tor_upstream_mux_toggle.py`
+
+## 1. Topology Type
+- **Topology:** `t0` dual ToR topology.
+- **Inference:** The module-level `pytestmark` applies `@pytest.mark.topology('t0')`, and the fixtures such as `apply_mock_dual_tor_tables` and `toggle_all_simulator_ports` clearly target the dual ToR simulation environment used for T0 testbeds.【F:tests/dualtor/test_standby_tor_upstream_mux_toggle.py†L18-L36】
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate that a standby ToR can toggle its MUX state upstream without leaving stale CRM nexthop resources and that traffic forwarding behavior (drop vs. forward) matches the MUX state.
+- **Broader Context:** In SONiC dual ToR deployments, traffic destined upstream must be blocked when the ToR is in standby and allowed when active. The test ensures MUX state transitions preserve control-plane resource accounting via CRM and enforce correct forwarding behavior using simulated dual ToR tables and mux control utilities.【F:tests/dualtor/test_standby_tor_upstream_mux_toggle.py†L18-L80】
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_standby_tor_upstream_mux_toggle`
+- **Intent & Logic:**
+  1. Select a random interface/IP pair from the standby ToR (`rand_selected_interface`).
+  2. Force the interface MUX to `standby`, send 100 packets, and assert they are dropped while capturing CRM baseline data (`crm_facts0`).
+  3. Toggle the MUX to `active`, resend traffic, and confirm packets now forward upstream without drops.
+  4. Toggle back to `standby`, verify drops resume, collect new CRM facts (`crm_facts1`), and compare them to ensure no unexpected resource deltas for non-`vs` ASICs.
+- **Checks:** Traffic verification uses `verify_upstream_traffic` with `drop` flags, and CRM differences are validated through `compare_crm_facts` and a `pytest_assert` wrapper.
+- **Relevance:** Confirms the MUX control logic preserves forwarding semantics and CRM resource stability across toggles, preventing stale nexthops when switching between standby and active states.【F:tests/dualtor/test_standby_tor_upstream_mux_toggle.py†L38-L80】
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `apply_mock_dual_tor_tables`, `apply_mock_dual_tor_kernel_configs`: prepare dual ToR routing tables and kernel state for simulation.
+  - `run_garp_service`, `run_icmp_responder`: ensure ARP and ICMP responders on PTF host to support traffic generation.
+  - `test_cleanup`: module-scoped fixture issuing `config_reload` after tests to restore DUT configuration.
+  - Test parameters: `rand_selected_dut`, `tbinfo`, `ptfadapter`, `rand_selected_interface`, `toggle_all_simulator_ports`, `set_crm_polling_interval` provide device context, testbed metadata, traffic generator, interface selection, MUX control, and CRM sampling cadence.
+- **Libraries/Helpers:** Dual ToR mock utilities, MUX simulator control, CRM helpers, and config reload ensure accurate simulation and cleanup.
+- **Topology Constraints:** Requires dual ToR capable T0 testbed with MUX simulator support; implied by fixtures but not explicitly documented elsewhere in this file.【F:tests/dualtor/test_standby_tor_upstream_mux_toggle.py†L18-L69】
+
+## 5. Key Inputs and Parameters
+- `rand_selected_interface`: Supplies `(itfs, ip)` tuple specifying the target server-facing interface and its IP, dictating which MUX leg to toggle and traffic destination.
+- `PKT_NUM = 100`: Number of test packets sent per verification step.
+- `PAUSE_TIME = 10`: Sleep duration after toggling to allow MUX state convergence.
+- `toggle_all_simulator_ports`: Controls the MUX simulator for the selected port.
+- `set_crm_polling_interval`: Ensures CRM counters are sampled frequently enough for comparison.
+- Device facts like `rand_selected_dut.facts['asic_type']` determine whether CRM differences must be zero (non-`vs` hardware) before asserting.【F:tests/dualtor/test_standby_tor_upstream_mux_toggle.py†L24-L80】
+
+## 6. External Libraries and Modules
+- `pytest`: Test framework providing fixtures, markers, and assertions.
+- `logging`: Creates a logger (unused in current logic but available for debugging).
+- `json`, `time`: Standard library modules for formatting CRM diffs and introducing waits.
+- `tests.common.dualtor.dual_tor_mock`: Provides dual ToR mock fixtures/utilities (imported via wildcard, includes `set_mux_state`).
+- `tests.common.helpers.assertions.pytest_assert`: Enhanced assertion wrapper for clearer failure messages.
+- `tests.common.dualtor.dual_tor_utils`: Supplies helpers like `rand_selected_interface`, `verify_upstream_traffic`, and `get_crm_nexthop_counter`.
+- `tests.common.utilities.compare_crm_facts`: Compares CRM snapshots for resource drift.
+- `tests.common.config_reload.config_reload`: Restores DUT configuration post-test.
+- `tests.common.dualtor.mux_simulator_control.toggle_all_simulator_ports`: Fixture to manipulate the dual ToR MUX simulator.
+- `tests.common.fixtures.ptfhost_utils`: Provides PTF host utilities for MAC addressing, GARP, and ICMP responders.
+These modules collectively enable dual ToR simulation, traffic verification, CRM introspection, and environment cleanup.【F:tests/dualtor/test_standby_tor_upstream_mux_toggle.py†L1-L69】
+
+## 7. Unspecified Items
+- Additional parameters from `testbed.yaml`, group variables, or CLI options are **Not specified** within this test file.
+- Hardware prerequisites beyond dual ToR capability are **Not specified** in the source code snippet.【F:tests/dualtor/test_standby_tor_upstream_mux_toggle.py†L1-L80】
+


### PR DESCRIPTION
## Summary
- document the dual ToR standby upstream mux toggle test in the t0 topology test plan
- capture topology, objectives, dependencies, parameters, and external helpers used by the test

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da44e97f90832fac9e33a1eca37419