### PR TITLE
Add analyzer for DHCP relay GCU tests

### DIFF
--- a/docs/t0_topology_testplan/generic_config_updater/test_dhcp_relay_analyzer.md
+++ b/docs/t0_topology_testplan/generic_config_updater/test_dhcp_relay_analyzer.md
@@ -1,0 +1,63 @@
+# DHCP Relay Generic Config Updater Test Analyzer
+
+## 1. Topology Type
+- **Topology:** `t0` with multi-ASIC variant `m0`.
+- **Inference:** The module-level `pytestmark` applies `pytest.mark.topology('t0', 'm0')`, signalling the tests expect a T0-style fabric and are also valid for `m0` multi-ASIC setups where appropriate. This implies one SONiC DUT connected to T0 fanout neighbors.
+
+## 2. Overall Test Case Purpose
+- **High-level goal:** Validate that the Generic Config Updater (GCU) correctly manages DHCP relay server entries within VLAN configurations and maintains service health.
+- **Context:** Within SONiC regression, GCU tests ensure JSON patch operations (add/remove/replace) on CONFIG_DB tables behave as expected. This file focuses on DHCP relay helpers in the `VLAN` table, verifying both configuration persistence and runtime process state after updates.
+
+## 3. Detailed Breakdown of Sub-Testcases
+- **`test_dhcp_relay_tc1_rm_nonexist`**
+  - Attempts to remove a DHCP server entry index that does not exist in the default setup for the selected VLAN.
+  - Expects the GCU operation to fail, confirming that invalid removals are rejected without side effects.
+  - Supports the goal by ensuring error handling prevents unintended configuration drift.
+- **`test_dhcp_relay_tc2_add_exist`**
+  - Tries to add a DHCP server IP that is already present in the VLAN helper list.
+  - Expects the patch application to fail, demonstrating that duplicates are not silently introduced.
+  - Guards against config corruption and enforces idempotent behavior of DHCP helper lists.
+- **`test_dhcp_relay_tc3_add_and_rm`**
+  - Issues a combined JSON patch that removes a helper entry from one VLAN and adds a new helper to another.
+  - Confirms successful patch application, verifies the DHCP relay container remains healthy, and checks resulting helper IPs via process inspection.
+  - Validates that mixed operations succeed atomically and that service state reflects the new configuration.
+- **`test_dhcp_relay_tc4_replace`**
+  - Replaces an existing DHCP server entry with a different IP address in the VLAN helper list.
+  - Expects success, checks DHCP relay service status, and asserts the new helper IP is present while the old one is absent.
+  - Ensures update semantics function correctly and that DHCP relay responds to helper changes.
+
+### Supporting Fixtures and Helpers
+- **`setup_vlan` (autouse)**
+  - Creates checkpoints, builds temporary VLANs with DHCP helpers, ensures services run, and handles cleanup via rollback.
+  - Provides a consistent environment for each test, crucial for reliable GCU validation.
+- **`vlan_intfs_dict`, `vlan_intfs_list`, `first_avai_vlan_port`**
+  - Generate VLAN identifiers, interface lists, and select member ports to set up temporary VLANs.
+  - Supply the per-test data used by JSON patches.
+- **Utility functions** such as `create_test_vlans`, `default_setup`, `ensure_dhcp_relay_running`, `ensure_dhcp_server_up`, `dhcp_severs_by_vlanid`, and `expect_res_success_by_vlanid`
+  - Prepare and verify the configuration and runtime state, and are used across multiple tests for consistency.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:** `rand_selected_dut`, `duthosts`, `rand_one_dut_hostname`, `cfg_facts`, `tbinfo`, `utils_vlan_intfs_dict_orig`, and fixtures defined within the file provide device handles, configuration data, and VLAN setup details.
+- **Topology constraints:** Requires a DUT capable of supporting VLAN creation and DHCP relay services, matching T0/m0 capabilities.
+- **Services:** DHCP relay container must be available for `docker exec` checks; CONFIG_DB access via `sonic-db-cli` is required.
+- These dependencies ensure the environment can apply JSON patches, manipulate CONFIG_DB entries, and validate resulting services.
+
+## 5. Key Inputs and Parameters
+- **VLAN IDs:** Dynamically chosen new VLANs (e.g., 108, 109) created by `utils_vlan_intfs_dict_add` to act as test targets.
+- **DHCP Helper IPs:** Generated sequences like `192.0.<VLAN>.1-4` for default setup, with additional values introduced or removed per test.
+- **Timeout Constants:** `DHCP_RELAY_TIMEOUT` and `DHCP_RELAY_INTERVAL` control wait loops ensuring relay processes are running before validation.
+- **Checkpoints Names:** `SETUP_ENV_CP` and `CONFIG_ADD_DEFAULT` (constant unused) support rollback operations ensuring isolation between tests.
+
+## 6. External Libraries and Modules
+- **Standard:** `logging` for diagnostics.
+- **Pytest:** `pytest`, along with fixtures and markers for topology selection.
+- **Test utilities:**
+  - `tests.common.helpers.assertions.pytest_assert` for consistent assertion handling.
+  - `tests.common.utilities.wait_until` for polling service status.
+  - `tests.common.fixtures.duthost_utils` (utilities to add VLAN interfaces and create test VLANs).
+  - `tests.common.gu_utils` providing JSON patch application, checkpoint management, and expectation helpers.
+  - `tests.common.dhcp_relay_utils.restart_dhcp_service` to restart the DHCP relay container after config changes.
+- These modules integrate SONiC-specific helpers with pytest to manipulate and verify DUT state.
+
+## 7. Unspecified Items
+- Details such as exact DUT hardware models, external DHCP server configuration, or precise neighbor topology beyond T0/m0 are **Not specified** in the test file.


### PR DESCRIPTION
## Summary
- add documentation summarizing the DHCP relay generic config updater test intent
- cover topology, dependencies, and per-test breakdowns for the DHCP relay test module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da4b354f14832faea8ff068cc6466f