### PR TITLE
Add documentation analyzer for directed broadcast IP forwarding test

### DIFF
--- a/docs/t0_topology_testplan/ipfwd/test_dir_bcast_analyzer.md
+++ b/docs/t0_topology_testplan/ipfwd/test_dir_bcast_analyzer.md
@@ -1,0 +1,60 @@
+# Test Case Analysis: `tests/ipfwd/test_dir_bcast.py`
+
+## 1. Topology Type
+- **Declared topology markers:** The module-level `pytestmark` includes `pytest.mark.topology('t0', 'm0', 'mx')`, indicating that the test is designed to execute on T0, M0, and MX topologies.
+- **Inference method:** The `tbinfo` fixture is consulted inside the test to read `tbinfo['topo']['name']` and `tbinfo['topo']['type']`. The helper function `get_ptf_src_ports` looks up `UPSTREAM_NEIGHBOR_MAP[tbinfo["topo"]["type"]]` to determine upstream neighbors, confirming the test adapts to the topology type reported in the `tbinfo` metadata rather than being hard-coded for a single layout.
+
+## 2. Overall Test Case Purpose
+- **High-level goal:** Validate directed broadcast forwarding behavior from the device under test (DUT) to downstream VLAN hosts by executing a PTF-based test (`dir_bcast_test.BcastTest`). The test ensures that the DUT properly handles directed broadcasts from upstream interfaces to VLAN-attached ports according to SONiC forwarding expectations.
+- **Context in SONiC testing:** Within the SONiC/pytest framework, this scenario checks IP forwarding correctness, confirming that routing configuration and mux state (for dual ToR) permit directed broadcasts to reach the expected downstream ports. It leverages minigraph facts and PTF infrastructure typical in SONiC system-level dataplane validations.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_dir_bcast`
+- **Intent & logic:**
+  1. Select a DUT (`duthost = duthosts[rand_one_dut_hostname]`) based on the randomized hostname fixture.
+  2. Retrieve the current testbed type and topology metadata via `tbinfo`.
+  3. Gather extended minigraph facts from the DUT to obtain VLAN interfaces, members, and port indices.
+  4. Construct a PTF port map:
+     - Determine upstream (source) PTF ports using `get_ptf_src_ports`, which consults `UPSTREAM_NEIGHBOR_MAP` and `get_neighbor_ptf_port_list`.
+     - Determine VLAN subnets and associated destination PTF ports via `get_ptf_dst_ports`, filtering only active members when operating in a dual ToR topology by checking `show mux status`.
+     - Write the resulting structure to `/root/ptf_test_port_map.json` on the PTF host.
+  5. Launch the PTF test case `dir_bcast_test.BcastTest` with parameters describing the testbed type, router MAC, and port map file, capturing logs under `/tmp/dir_bcast.BcastTest.<timestamp>.log`.
+- **Relevance:** This single test drives the entire directed broadcast validation by orchestrating topology-aware port selection and handing off execution to the PTF dataplane test. Ensuring the correct preparation and invocation of the PTF test is essential for verifying SONiC's broadcast forwarding behavior.
+
+### Helper Functions
+- **`get_ptf_src_ports`**: Determines upstream PTF ports based on topology type and neighbor relationships. Critical for ensuring traffic originates from interfaces that mimic upstream routers.
+- **`get_ptf_dst_ports`**: Builds the mapping of VLAN subnets to destination PTF ports. It accounts for dual ToR mux status to avoid inactive ports, ensuring only valid egress interfaces are tested.
+- **`ptf_test_port_map`**: Aggregates source/destination port data and writes the JSON map to the PTF host, serving as the configuration input for the PTF broadcast test.
+- These helpers ensure the main test can dynamically adapt to various topology instances and accurately represent the DUT's connectivity.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `duthosts`, `rand_one_dut_hostname`: Provide access to DUT instances and select one for testing.
+  - `ptfhost`: Interface to the PTF container for copying files and running tests.
+  - `tbinfo`: Supplies topology metadata (`type`, `name`, neighbor info).
+  - `toggle_all_simulator_ports_to_rand_selected_tor_m`: Ensures dual ToR simulator ports align with the randomly selected active ToR before testing.
+  - `copy_ptftests_directory`: Ensures PTF test files are available on the PTF host (imported for its fixture side-effect).
+- **Topology constraints:** Requires a topology compatible with the specified markers (T0, M0, MX) and, when dual ToR is present, mux simulator control via the fixture.
+- **Device capabilities:** DUT must support `show mux status` command when operating in dual ToR environments to identify active ports.
+
+## 5. Key Inputs and Parameters
+- `tbinfo['topo']['type']` / `tbinfo['topo']['name']`: Define topology behavior and testbed type, guiding port selection and PTF parameterization.
+- `UPSTREAM_NEIGHBOR_MAP`: Maps topology types to upstream neighbor names for source port discovery.
+- `mg_facts`: Extended minigraph data (VLANs, interfaces, port indices) used to derive destination ports and VLAN subnets.
+- `duthost.facts['router_mac']`: Router MAC address passed to the PTF test to craft packets.
+- `PTF_TEST_PORT_MAP`: Path to the generated JSON mapping consumed by the PTF broadcast test.
+- `testbed_type`: Passed into the PTF runner to select behavior within the PTF script.
+
+## 6. External Libraries and Modules
+- `pytest`: Testing framework used for fixtures, marks, and test execution control.
+- `json`: Serializes the port map to JSON for transfer to the PTF host.
+- `logging`: Obtains a module-specific logger (though not actively used in this file beyond initialization).
+- `datetime` from Python standard library: Generates timestamped log filenames.
+- `tests.ptf_runner.ptf_runner`: Helper to execute tests inside the PTF container.
+- `tests.common.fixtures.ptfhost_utils.copy_ptftests_directory`: Fixture ensuring PTF tests are synchronized to the PTF host.
+- `tests.common.dualtor.mux_simulator_control.toggle_all_simulator_ports_to_rand_selected_tor_m`: Fixture managing dual ToR mux simulator state.
+- `tests.common.utilities.get_neighbor_ptf_port_list`: Utility to derive PTF port indices from neighbor descriptions.
+- `tests.common.helpers.constants.UPSTREAM_NEIGHBOR_MAP`: Topology-to-neighbor mapping constant guiding source port discovery.
+
+## 7. Unspecified Items
+- Specific expected packet behaviors, pass/fail criteria inside `dir_bcast_test.BcastTest`, and exact topology diagrams are **Not specified** within this file.


### PR DESCRIPTION
## Summary
- add analyzer documentation for tests/ipfwd/test_dir_bcast.py detailing topology, dependencies, and validation goals

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68da63d8dbc08328b79cc0c07f75f6d9