### PR TITLE
Add analyzer for PFC pause QoS test

### DIFF
--- a/docs/t0_topology_testplan/qos/test_pfc_pause_analyzer.md
+++ b/docs/t0_topology_testplan/qos/test_pfc_pause_analyzer.md
@@ -1,0 +1,67 @@
+# Test Plan Analysis: `tests/qos/test_pfc_pause.py`
+
+## 1. Topology Type
+- **Topology:** `t0`.
+- **Inference:** The module-level marker sets `pytestmark = [pytest.mark.topology('t0')]`, explicitly restricting execution to the T0 topology that features a single SONiC DUT connected to multiple server-facing ports through a fanout. The fixture `pfc_test_setup` gathers VLAN member interfaces that correspond to server-facing links in T0 environments, reinforcing the topology assumption.
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate Priority Flow Control (PFC) pause behavior on SONiC devices operating in a T0 data center topology.
+- **Scope within SONiC testing:** Ensures that lossless queues honor PFC pause frames without impacting other priorities and that normal traffic forwarding resumes when pause signaling is absent. The tests interact with SONiC QoS configuration, PFC watchdog, and fanout-triggered pause frame generators to confirm correct QoS handling under controlled traffic scenarios.
+
+## 3. Detailed Breakdown of Sub-Testcases
+
+### 3.1 Helper: `pfc_test_setup`
+- **Role:** Module-scoped autouse fixture that prepares per-VLAN interface, IP, and MAC mappings and temporarily stops the DUT PFC watchdog. It collects DUT interfaces, resolves associated PTF ports, provisions test IP addresses (including dual ToR handling via `mux_cable_server_ip`), and returns a list consumed by subsequent tests. Post-tests, it restores the DUT state by clearing FDB entries and re-enabling the watchdog.
+- **Relevance:** Supplies foundational configuration and ensures consistent state for all PFC pause scenarios.
+
+### 3.2 Helper: `run_test`
+- **Role:** Shared execution routine that drives the PTF script `pfc_pause_test.py`, optionally triggers pause storms through `PFCStorm`, and compiles per-interface pass/total iteration counts.
+- **Logic Highlights:**
+  - Clears DUT PFC counters before traffic runs.
+  - Derives peer device information from `conn_graph_facts` to initialize the pause generator on fanout switches.
+  - Constructs PTF command-line parameters (DSCP under test, background DSCP, queue pause expectation, VLAN ID, etc.).
+  - Parses PTF output to return success ratios per interface.
+- **Relevance:** Centralizes traffic generation and verification for both subtests, ensuring consistent validation metrics.
+
+### 3.3 Test: `test_pfc_pause_lossless`
+- **Intent:** Confirm that sending PFC pause frames for a designated lossless priority pauses only the targeted queue while allowing other priorities to continue forwarding.
+- **Process:**
+  - Selects a lossless priority via `enum_dut_lossless_prio` fixture and maps it to DSCP values using `lossless_prio_dscp_map`.
+  - Chooses background DSCPs from other lossless and representative lossy priorities based on `get_max_priority`.
+  - Invokes `run_test` with `queue_paused=True`, `send_pause=True`, and `pfc_pause=True` so that the PFC storm tool transmits pause frames at the specified priority.
+  - Validates that the PTF results meet a pass ratio threshold; any deficit flags errors tied to specific interfaces/DSCP combinations.
+- **Importance:** Verifies correct PFC behavior—lossless traffic should be paused on demand, and QoS isolation prevents cross-priority impact.
+
+### 3.4 Test: `test_no_pfc`
+- **Intent:** Ensure that in the absence of pause frames, both lossless and lossy priorities forward traffic without unintended drops.
+- **Process:**
+  - Utilizes the same priority/DSCP selection logic, but skips if the selected lossless priority is not enabled on the test port.
+  - Calls `run_test` with `queue_paused=False`, `send_pause=False`, and `pfc_pause=None`, meaning no PFC storm is triggered.
+  - Evaluates PTF results to confirm that traffic passes above the threshold when no pause frames are present.
+- **Importance:** Provides the negative control for PFC validation, ensuring no unexpected throttling when pause conditions are absent.
+
+## 4. Dependencies and Prerequisites
+- **PyTest Fixtures:** `pfc_test_setup`, `fanouthosts`, `duthost/duthosts`, `ptfhost`, `conn_graph_facts`, `fanout_graph_facts`, `lossless_prio_dscp_map`, `enum_dut_lossless_prio`, `rand_selected_dut`, `setup_standby_ports_on_rand_unselected_tor`, `toggle_all_simulator_ports_to_rand_selected_tor` (dual ToR specific).
+- **Topology Constraints:** Requires a T0 or dual ToR testbed with accessible fanout devices capable of generating pause frames and a PTF host with the `pfc_pause_test.py` script.
+- **State Dependencies:** The fixture stops the PFC watchdog and clears FDB entries before tests; post-test cleanup re-enables these services to preserve DUT stability.
+
+## 5. Key Inputs and Parameters
+- **Traffic Parameters:** `traffic_params` dictionary controls DSCP values for test and background flows (`dscp`, `dscp_bg`).
+- **PTF Execution Settings:** `PTF_PKT_COUNT`, `PTF_PKT_INTVL_SEC`, `PTF_PASS_RATIO_THRESH`, and VLAN IDs inform packet injection cadence and validation criteria.
+- **Pause Control Flags:** Function parameters `queue_paused`, `send_pause`, `pfc_pause`, and `pause_prio` direct whether PFC storms should be initiated and which queue is targeted.
+- **Topology Metadata:** `tbinfo['topo']['name']` guides address assignment (including dual ToR IP resolution).
+
+## 6. External Libraries and Modules
+- **Standard/Third-Party:** `logging`, `os`, `time`, `pytest`, `natsort.natsorted` (sorting helper).
+- **SONiC Test Utilities:**
+  - `.qos_helpers`: interface/VLAN discovery and utility helpers (`get_all_vlans`, `get_phy_intfs`, etc.).
+  - `.qos_fixtures`: provides `lossless_prio_dscp_map` mapping fixture.
+  - `tests.common.helpers.pfc_storm.PFCStorm`: orchestrates PFC pause generation on fanout hardware.
+  - `tests.common.helpers.assertions.pytest_assert`: enhanced assertion helper.
+  - Dual ToR utilities (`mux_cable_server_ip`, `toggle_all_simulator_ports_to_rand_selected_tor`) to adapt to multi-ToR labs.
+  - PTF host utilities (`copy_ptftests_directory`, `change_mac_addresses`, `set_ptf_port_mapping_mode`) for environment setup (imported for fixture activation).
+  - Connection graph fixtures (`conn_graph_facts`, `fanout_graph_facts`) supply topology and peer-port details.
+
+## 7. Unspecified Items
+- Additional configuration sources (e.g., exact `testbed.yaml` entries or group variable files) – **Not specified**.
+- Detailed criteria of `pfc_pause_test.py` PTF script beyond command-line parameters – **Not specified**.


### PR DESCRIPTION
## Summary
- add a topology and behavior analysis document for tests/qos/test_pfc_pause.py
- document fixtures, dependencies, and intent of PFC pause validation scenarios

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb06ed8308328bcae0ab95b59de32