### PR TITLE
Add documentation analyzer for RADV deployment test

### DIFF
--- a/docs/t0_topology_testplan/radv/test_radv_run_analyzer.md
+++ b/docs/t0_topology_testplan/radv/test_radv_run_analyzer.md
@@ -1,0 +1,46 @@
+# RADV Deployment ID Test Analyzer
+
+## 1. Topology Type
+- **Topology:** T0.
+- **Inference:** The module-level `pytestmark` applies `pytest.mark.topology('t0')`, explicitly binding the test to the T0 topology used in SONiC regression suites.【F:tests/radv/test_radv_run.py†L9-L15】
+
+## 2. Overall Test Case Purpose
+- **Goal:** Validate the behavior of the RADV (Router Advertisement Daemon) container when the device deployment ID is changed to the PO2VLAN-specific value and then reverted.
+- **Context:** Within the SONiC test framework, RADV advertises IPv6 prefixes to directly connected hosts. This test ensures that changing `DEVICE_METADATA|localhost:deployment_id` triggers the expected container restart behavior, the RADV service (`radvd`) does not remain running unexpectedly, and normal state can be restored afterward.【F:tests/radv/test_radv_run.py†L17-L37】
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_radv_deployment_id`
+- **Intent & Logic:**
+  1. Confirm the RADV container is initially running using `is_container_running`.
+  2. Persist the current deployment ID, then update it to `PO2VLAN_DEPLOYMENT_ID` (`8`) via `sonic-db-cli` on `CONFIG_DB`.
+  3. Regenerate the RADV supervisord configuration (`sonic-cfggen`) and restart the RADV service with `systemctl`.
+  4. Wait until the RADV container becomes healthy again (`wait_until` + `is_container_running`).
+  5. Verify that the internal `radvd` service is no longer active (`duthost.is_service_running`).
+  6. Restore the original deployment ID, regenerate configs, restart RADV, and ensure the container returns to a running state.
+- **Relevance:** Demonstrates that deployment ID modifications propagate correctly without leaving stale RADV services, preserving IPv6 advertisement integrity after configuration transitions.【F:tests/radv/test_radv_run.py†L17-L37】
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:** `duthost` provides access to DUT shell commands, service checks, and helpers. Required for interacting with CONFIG_DB and managing containers.【F:tests/radv/test_radv_run.py†L17-L37】
+- **Helpers:**
+  - `wait_until` polls for the RADV container to resume running after restart.【F:tests/radv/test_radv_run.py†L5-L6】【F:tests/radv/test_radv_run.py†L28-L29】
+  - `is_container_running` checks container state both before and after restarts.【F:tests/radv/test_radv_run.py†L6-L7】【F:tests/radv/test_radv_run.py†L18-L34】
+- **System Requirements:** Access to `sonic-db-cli`, `sonic-cfggen`, Docker, and systemd on the DUT to manipulate the RADV container and configuration. These tools are implicitly assumed by the test but not defined in the repository file (environment-provided).
+
+## 5. Key Inputs and Parameters
+- `PO2VLAN_DEPLOYMENT_ID = '8'`: Target deployment ID used to emulate PO2VLAN scenarios.【F:tests/radv/test_radv_run.py†L13-L14】
+- `duthost.shell` commands:
+  - `hget`/`hset` commands manipulate `CONFIG_DB` deployment ID, governing RADV behavior.
+  - `docker exec ... sonic-cfggen ...` rebuilds supervisord configuration.
+  - `systemctl reset-failed/restart radv` restarts the containerized RADV service.【F:tests/radv/test_radv_run.py†L20-L27】
+- `wait_until` timing parameters (`10`, `1`, `0`) determine retry duration and interval when waiting for container readiness.【F:tests/radv/test_radv_run.py†L28-L29】
+
+## 6. External Libraries and Modules
+- **`pytest`**: Supplies test structure, fixtures, and topology markers.【F:tests/radv/test_radv_run.py†L1-L2】【F:tests/radv/test_radv_run.py†L9-L15】
+- **`logging`**: Produces diagnostic output during test execution.【F:tests/radv/test_radv_run.py†L2-L10】
+- **`tests.common.utilities.wait_until`**: Utility for polling asynchronous conditions.【F:tests/radv/test_radv_run.py†L5-L6】
+- **`tests.common.helpers.dut_utils.is_container_running`**: Helper to query container status on the DUT.【F:tests/radv/test_radv_run.py†L6-L7】
+
+## 7. Unspecified Items
+- Detailed topology layout (specific number of VLANs/ports, neighbors) – **Not specified** in this file.
+- Exact fixture definitions (`duthost` implementation details) – **Not specified** here; provided elsewhere in the test framework.
+- Any additional configuration prerequisites or cleanup steps beyond those shown – **Not specified**.


### PR DESCRIPTION
## Summary
- add a topology and behavior analysis markdown for the RADV deployment ID regression test

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb0b0bc688328910ef15bbcade939