### PR TITLE
Add analyzer for REST API pytest plan

### DIFF
--- a/docs/t0_topology_testplan/restapi/test_restapi_analyzer.md
+++ b/docs/t0_topology_testplan/restapi/test_restapi_analyzer.md
@@ -1,0 +1,88 @@
+# REST API Test Plan Analyzer
+
+## 1. Topology Type
+- **Topology:** `t0`.
+- **Inference:** The test module is marked with `pytest.mark.topology('t0')`, explicitly scoping execution to the T0 Tor-like leaf-spine topology that provides VLAN members, VNET capabilities, and reboot coverage required by the REST API scenarios.【F:tests/restapi/test_restapi.py†L17-L61】
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate SONiC REST API functionality for control-plane configuration of reset status, VXLAN/VNET creation, VLAN and neighbor management, and route programming, including both positive (happy path) and negative (sad path) behaviors, as well as persistence across reboots.
+- **Context in SONiC/SpyTest:** Exercises the REST API Northbound interface to ensure that configuration changes applied through REST endpoints correctly reflect in the device state, survive config reloads and reboots, reject invalid or duplicate operations, and cleanly remove state—critical for automation systems orchestrating SONiC fabrics via REST.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_check_reset_status`
+- **Intent & Logic:**
+  - Queries the REST API reset status, toggles it from `true` to `false`, and verifies responses.
+  - Performs `config reload`, reapplies client certificates, and ensures reset status returns to default (`true`).
+  - Validates reset status transitions across fast, cold, and warm reboots by calling `check_reset_status_after_reboot` helper, confirming expected pre- and post-reboot values.【F:tests/restapi/test_restapi.py†L27-L105】
+- **Importance:** Demonstrates REST API status persistence and correct handling during reloads and reboots, ensuring management clients can rely on deterministic reset state.
+
+### Helper: `check_reset_status_after_reboot`
+- **Role:** Encapsulates reset status validation around a reboot cycle. It sets the status, triggers the specified reboot via `reboot()` helper, optionally waits for warm reboot finalizer, reapplies client certificates, and verifies the expected post-reboot status.【F:tests/restapi/test_restapi.py†L69-L105】
+- **Relevance:** Reused by `test_check_reset_status` to reduce duplication across fast, cold, and warm reboot validations.
+
+### Fixture: `cleanup_after_testing`
+- **Role:** Pytest fixture that reloads the DUT configuration after a test finishes to restore baseline state.【F:tests/restapi/test_restapi.py†L107-L114】
+- **Relevance:** Ensures subsequent tests start from a clean config database.
+
+### `test_data_path`
+- **Intent & Logic:**
+  - Ensures a default VXLAN tunnel exists, then exercises positive REST API flows to create two VNETs with associated VLANs, members, neighbors, and routes.
+  - Verifies each resource creation via GET calls and JSON assertions.
+  - Validates that invalid routes with incorrect CIDR are rejected (HTTP 207) and not present in subsequent queries.【F:tests/restapi/test_restapi.py†L118-L352】
+- **Importance:** Confirms REST API correctly provisions VXLAN/VNET datapath entities and enforces address validation.
+
+### `test_data_path_sad`
+- **Intent & Logic:**
+  - Repeats similar resource creation but deliberately submits duplicate creates (expecting 409 conflicts) and repeated route additions, validating idempotency and proper error handling.
+  - Confirms resources must be deleted in proper order by expecting failures when deletion is attempted prematurely.【F:tests/restapi/test_restapi.py†L354-L528】
+- **Importance:** Verifies REST API robustness against repeated or out-of-order operations, ensuring reliable automation behavior under error conditions.
+
+### `test_create_vrf`
+- **Intent & Logic:**
+  - Creates a VNET, adds multiple routes, verifies they exist, then deletes them and confirms removal.
+  - Focuses on route lifecycle management within a single VRF context.【F:tests/restapi/test_restapi.py†L536-L610】
+- **Importance:** Validates route CRUD operations via REST API and data plane synchronization timing.
+
+### `test_create_interface`
+- **Intent & Logic:**
+  - Provisions a VNET, VLAN, member, neighbor, and then exercises full deletion workflow, verifying each removal returns HTTP 404 on GET.
+  - Demonstrates REST API delete endpoints and cleanup sequence.【F:tests/restapi/test_restapi.py†L618-L744】
+- **Importance:** Ensures REST API supports interface teardown and that resources are removed cleanly.
+
+### `test_create_interface_sad`
+- **Intent & Logic:**
+  - Mirrors the create/delete flow but stresses negative scenarios: duplicate creations (expect 409), repeated deletions (expect 404), and invalid deletion order (expect 409 when deleting VLAN before dependencies removed).
+  - Confirms REST API enforces dependency constraints and idempotent error responses.【F:tests/restapi/test_restapi.py†L748-L1008】
+- **Importance:** Validates defensive behavior of REST API for interface-related resources, crucial for preventing configuration drift.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `construct_url`, `duthosts`, `rand_one_dut_hostname`, `localhost`, `rand_selected_dut`, `vlan_members`, `is_support_warm_fast_reboot`—provide DUT connections, selection, REST endpoint URL, and environmental capabilities. Definitions are external (not specified here).【F:tests/restapi/test_restapi.py†L27-L1008】
+  - `cleanup_after_testing` fixture within file performs post-test config reload.【F:tests/restapi/test_restapi.py†L107-L114】
+- **Helpers:**
+  - `config_reload` to restore device state.【F:tests/restapi/test_restapi.py†L8-L105】
+  - `reboot` to trigger DUT reboots with safe handling.【F:tests/restapi/test_restapi.py†L8-L105】
+  - `apply_cert_config` to reconfigure REST API client certificates after reload/reboot.【F:tests/restapi/test_restapi.py†L9-L105】
+  - `Restapi` class providing REST endpoint wrappers.【F:tests/restapi/test_restapi.py†L10-L352】
+- **Topology Constraints:** Requires `t0` topology with available VLAN members (skips tests otherwise).【F:tests/restapi/test_restapi.py†L158-L166】
+
+## 5. Key Inputs and Parameters
+- **REST API URL:** Provided by `construct_url`, controlling target REST server endpoint (not specified within file).
+- **Client Certificates:** `restapiclient.crt` and `restapiclient.key` used by `Restapi` helper to authenticate.【F:tests/restapi/test_restapi.py†L21-L24】
+- **VNET/VLAN IDs and VNIDs:** Hard-coded parameters (e.g., VNET IDs `vnet-guid-2`, `vnet-guid-3`, etc.; VNIDs `7036001/2`, `7039114/7039115`) drive REST API payloads to verify resource handling.【F:tests/restapi/test_restapi.py†L135-L1008】
+- **IP prefixes, next-hops, MAC addresses:** Provided within JSON payload strings to test route programming and validation logic.【F:tests/restapi/test_restapi.py†L188-L1008】
+- **Reboot Type Controls:** Strings `'fast'`, `'cold'`, `'warm'` passed into `check_reset_status_after_reboot` to select reboot method.【F:tests/restapi/test_restapi.py†L49-L105】
+
+## 6. External Libraries and Modules
+- `pytest`: Testing framework for fixtures, marks, and assertions.【F:tests/restapi/test_restapi.py†L1-L19】
+- `time`: Adds delays ensuring route propagation before verification.【F:tests/restapi/test_restapi.py†L1-L352】
+- `logging`: Provides structured logging within tests.【F:tests/restapi/test_restapi.py†L2-L352】
+- `json`: Parses REST API responses for validation.【F:tests/restapi/test_restapi.py†L3-L352】
+- `tests.common.helpers.assertions.pytest_assert`: Provides enhanced assertion helper with logging context.【F:tests/restapi/test_restapi.py†L5-L352】
+- `tests.common.config_reload`: Restores DUT configuration to baseline.【F:tests/restapi/test_restapi.py†L6-L114】
+- `tests.common.reboot.reboot`: Executes DUT reboots under test control.【F:tests/restapi/test_restapi.py†L7-L105】
+- `helper.apply_cert_config`: Applies REST API client certificate configuration post-reload/reboot.【F:tests/restapi/test_restapi.py†L8-L105】
+- `restapi_operations.Restapi`: Abstraction layer for invoking REST API endpoints (get/post/patch/delete).【F:tests/restapi/test_restapi.py†L9-L352】
+
+## 7. Unspecified Items
+- Fixture implementations (`construct_url`, `vlan_members`, etc.), REST API server setup details, and exact topology inventory are **Not specified** within this test file.


### PR DESCRIPTION
## Summary
- add a topology and intent analysis document for the REST API pytest suite

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb23957548328bd940314b5d4bd92