### PR TITLE
Add analyzer documentation for duplicate route test

### DIFF
--- a/docs/t0_topology_testplan/route/test_duplicate_route_analyzer.md
+++ b/docs/t0_topology_testplan/route/test_duplicate_route_analyzer.md
@@ -1,0 +1,48 @@
+# Duplicate Route Test Analyzer
+
+## 1. Topology Type
+- **Topology**: `t0` (also marked for `m0` and `any`).
+- **Inference**: The file-level `pytestmark` declares `pytest.mark.topology("t0", "m0", "any")`, indicating the test is primarily authored for T0 topologies but is permitted to run on additional topologies where front-end ASIC behavior matches the expectations. The fixtures `enum_rand_one_per_hwsku_frontend_hostname` and `enum_rand_one_frontend_asic_index` further imply a front-end DUT selection consistent with T0-style leaf topologies.
+
+## 2. Overall Test Case Purpose
+- **High-level Goal**: Validate that SONiC correctly handles attempts to program duplicate static routes without causing orchagent crashes or restarts.
+- **Framework Context**: Within the SONiC pytest infrastructure, this test exercises route programming via `swssconfig` while monitoring SWSS/orchagent stability and log outputs. It ensures resilience and correctness in route management operations, which are critical for consistent control plane behavior in T0 deployments.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_duplicate_routes`
+- **Intent & Logic**: 
+  - Captures the existing `orchagent` PID, then applies a generated static route configuration (potentially containing duplicates) through `swssconfig`.
+  - Waits for route propagation, with extended delay when running on chassis/t2 topologies.
+  - Verifies that orchagent remains running and its PID is unchanged, indicating no crash or restart occurred due to duplicate route handling.
+- **Relevance**: Confirms robustness of route application workflows and ensures that duplicate route entries do not destabilize the control plane.
+
+### Supporting Fixtures and Helpers
+- **`setup_routes` (fixture)**: Prepares the DUT by selecting loopback or VLAN interfaces (parameterized via `interface_types`), gathering IP data from Config DB, generating interfaces and neighbor relationships through `generate_intf_neigh`, and creating temporary route configuration files via `generate_route_file`. It also applies the temporary setup (`prepare_dut`) and ensures cleanup (`cleanup_dut`) post-test.
+- **`interface_types` (fixture)**: Parameterizes the test over Loopback and Vlan interfaces to cover multiple interface contexts for route injection.
+- **`verify_expected_loganalyzer_logs` (autouse fixture)**: Configures Loganalyzer expectations to ensure duplicate route error logs are appropriately captured or ignored, validating logging behavior alongside functionality.
+- **`reload_dut` (module-level autouse fixture)**: Reloads the DUT configuration after test completion to restore baseline state.
+- **Helper Functions**: 
+  - `get_cfg_facts` retrieves Config DB data per ASIC namespace.
+  - `get_intf_ips` parses interface IP assignments from Config DB facts.
+  - These helpers support `setup_routes` by supplying accurate interface information for route generation.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures**: `duthosts`, `enum_rand_one_per_hwsku_frontend_hostname`, `enum_rand_one_frontend_asic_index`, `ip_versions`, `loganalyzer`, and the fixtures defined in this file (`interface_types`, `setup_routes`, `verify_expected_loganalyzer_logs`, `reload_dut`).
+- **Utilities/Helpers**: `config_reload`, `generate_intf_neigh`, `generate_route_file`, `prepare_dut`, `cleanup_dut`, `verify_orchagent_running_or_assert` from the SONiC test common libraries.
+- **Topology Constraints**: Requires at least one front-end ASIC with loopback or VLAN interfaces configured with IP addresses; depends on availability of T0-like topology characteristics (front-end device with routable interfaces and neighbors).
+
+## 5. Key Inputs and Parameters
+- **`enum_rand_one_per_hwsku_frontend_hostname`**: Randomly selects a DUT representative for the HW SKU, ensuring coverage across devices.
+- **`enum_rand_one_frontend_asic_index`**: Provides ASIC index for multi-ASIC platforms, guiding namespace-specific operations.
+- **`ip_versions`**: Determines whether IPv4 or IPv6 routes are generated and validated.
+- **`interface_types`**: Chooses between Loopback and VLAN interfaces for route injection scenarios.
+- **Config DB Facts**: Pulled via `get_cfg_facts` to locate actual interface IP assignments used in test route generation.
+- **Temporary Route File (`route_file_set`)**: Generated JSON payload consumed by `swssconfig` to apply routes.
+
+## 6. External Libraries and Modules
+- **Standard/Python**: `json`, `random`, `logging`, `time.sleep`, and `netaddr.IPNetwork` for data handling, randomness, logging, delays, and IP parsing.
+- **Pytest**: Provides test structure, fixtures, marks, and assertions (`pytest`, `pytest_assert`, `pytest_require`).
+- **SONiC Test Utilities**: Modules under `tests.common` and `tests.route.utils` supply configuration management, neighbor generation, and verification helpers required for orchestrating DUT state and validations.
+
+## 7. Unspecified Items
+- Any explicit references to `testbed.yaml`, group variables, or CLI parameters beyond the fixtures mentioned are **Not specified** in this file.


### PR DESCRIPTION
## Summary
- add analyzer documentation describing topology, fixtures, and purpose of `tests/route/test_duplicate_route.py`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbb26c27748328812bc40db370ff37