### PR TITLE
Add analyzer doc for sub port L2 forwarding test

### DIFF
--- a/docs/t0_topology_testplan/sub_port_interfaces/test_sub_port_l2_forwarding_analyzer.md
+++ b/docs/t0_topology_testplan/sub_port_interfaces/test_sub_port_l2_forwarding_analyzer.md
@@ -1,0 +1,49 @@
+# Test Case Analysis: `tests/sub_port_interfaces/test_sub_port_l2_forwarding.py`
+
+## 1. Topology Type
+- **Topology:** `t0`.
+- **Inference:** The module-level `pytestmark` applies `pytest.mark.topology("t0")`, indicating the test is intended for the T0 fanout topology with PTF-connected servers.
+
+## 2. Overall Test Case Purpose
+- **High-level goal:** Validate that sub-interfaces configured on front-panel ports do **not** perform Layer-2 forwarding. Frames injected into a sub-port should neither reach other sub-ports/subinterfaces nor the SONiC CPU, confirming L2 isolation requirements for routed sub-interfaces.
+- **Context in SONiC automation:** Within the SONiC Pytest infrastructure, sub-port scenarios ensure compliance with routing pipeline expectations—sub-interfaces should behave as pure Layer-3 termination points without unintended switching/bridging behavior.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_sub_port_l2_forwarding`
+- **Intent & flow:**
+  - Pulls a random sub-port definition and associated metadata (physical port, VLAN ID, connected PTF index) via `testbed_params` and `test_sub_port` fixtures.
+  - Builds several tagged Ethernet test frames (`generate_eth_packets` fixture) whose payload contains a fingerprint string. Destinations include: a dummy unicast, broadcast, and MAC of a different sub-port's peer to exercise various L2 forwarding possibilities.
+  - Wraps packet transmission within `check_no_cpu_packets`, a context manager starting `tcpdump` on the DUT sub-interface to capture CPU-bound frames and asserting none carry the fingerprint.
+  - Sends each packet multiple times (`PACKET_COUNT`) from the PTF port corresponding to the chosen sub-port, waits, and verifies that no packets with the fingerprint arrive on any other PTF port queues via `verify_no_packet_received`.
+- **Why it matters:** Demonstrates that sub-interfaces drop/terminate L2 traffic instead of flooding or forwarding, preventing unintended Layer-2 connectivity that could break routing isolation guarantees.
+
+### Helper Fixtures & Utilities
+- **`testbed_params`:** Gathers sub-port configuration from `define_sub_ports_configuration`, augments it with physical port names, VLAN IDs, and mapped PTF indices derived from DUT minigraph facts. Provides the foundational mapping for packet injection and validation.
+- **`test_sub_port`:** Randomly selects one sub-port entry to broaden coverage across runs.
+- **`generate_eth_packets`:** Produces VLAN-tagged Ethernet frames with deterministic payload fingerprints and varying destination MACs to test both unicast and broadcast behaviors.
+- **In-test helpers:**
+  - `check_no_cpu_packets`: Ensures SONiC CPU does not receive the fingerprinted traffic by running `tcpdump` on the target sub-interface.
+  - `verify_no_packet_received`: Confirms no other PTF ports observed the fingerprinted frames, guarding against L2 leakage.
+
+## 4. Dependencies and Prerequisites
+- **Pytest fixtures:** `apply_config_on_the_dut`, `define_sub_ports_configuration`, `duthosts`, `rand_one_dut_hostname`, `tbinfo`, `ptfadapter`. These supply DUT access, topology metadata, sub-port configuration, and PTF dataplane control necessary for test orchestration.
+- **Topology constraints:** Requires a T0 topology with defined sub-ports and connected PTF interfaces representing neighbor servers.
+- **Utilities:** Relies on SONiC test infrastructure helpers (`tests.common.utilities`, `pytest_assert`) and Scapy/PTF tooling for packet generation and verification.
+
+## 5. Key Inputs and Parameters
+- **Sub-port definitions:** From `define_sub_ports_configuration` and minigraph facts (`mg_facts`), determine which physical port/VLAN combinations represent sub-interfaces and their associated PTF indices.
+- **Packet constants:** `PACKET_COUNT`, `PACKET_PAYLOAD_FINGERPRINT`, `TIME_WAIT_AFTER_SENDING_PACKET`, and `PACKET_SAVE_PATH` control packet iteration counts, unique identification, synchronization delays, and packet capture storage.
+- **Topology metadata:** `constants.VLAN_SUB_INTERFACE_SEPARATOR` guides parsing of sub-port names (e.g., `Ethernet0.10`).
+- **Runtime selection:** Random selection via `random.choice` introduces variability across executions to exercise different sub-ports.
+
+## 6. External Libraries and Modules
+- **`pytest`:** Pytest framework for fixtures and test execution.
+- **`random`, `logging`, `contextlib`, `time`, `tempfile`:** Python stdlib utilities for random selection, logging, context managers, timing, and temporary files.
+- **`scapy` (`Ether`, `Dot1Q`, `sniff`):** Crafting and analyzing Ethernet/VLAN packets.
+- **`ptf.testutils`:** Sending packets via the PTF dataplane.
+- **`tests.common.constants`, `tests.common.utilities`, `tests.common.helpers.assertions.pytest_assert`:** SONiC-specific helpers providing constants, packet dump utilities, and assertion wrappers.
+
+## 7. Unspecified Items
+- **Testbed inventory specifics (e.g., number of sub-ports, interface naming conventions beyond provided constants):** Not specified.
+- **Exact configuration applied by `apply_config_on_the_dut` or `define_sub_ports_configuration`:** Not specified.
+- **Expected DUT state before/after test (beyond absence of L2 forwarding):** Not specified.


### PR DESCRIPTION
## Summary
- document topology, purpose, fixtures, and dependencies for the sub-port L2 forwarding pytest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdb7ca37c8328a2c8a781296bb30c