### PR TITLE
Add analyzer doc for populate FDB test

### DIFF
--- a/docs/t0_topology_testplan/testbed_setup/test_populate_fdb_analyzer.md
+++ b/docs/t0_topology_testplan/testbed_setup/test_populate_fdb_analyzer.md
@@ -1,0 +1,33 @@
+# Test Case Analyzer: `tests/testbed_setup/test_populate_fdb.py`
+
+## 1. Topology Type
+- **Topology marks:** `t0`, `m0`, and `mx` are declared via `pytestmark`.
+- **Inference:** The simultaneous marks indicate the test is intended to run on multiple supported topologies. The presence of `t0` suggests a leaf-spine fabric with fanout, while `m0` and `mx` extend coverage to other multi-DUT/metro variants. This conclusion comes directly from the `pytest.mark.topology` declaration.
+
+## 2. Overall Test Case Purpose
+- **High-level goal:** Validate that the DUT's forwarding database (FDB) can be populated correctly via the `populate_fdb` fixture.
+- **Framework context:** Within the SONiC regression suite, FDB population checks ensure that Layer-2 reachability setup succeeds before functional forwarding tests. This test belongs to the `testbed_setup` stage, verifying prerequisite state for downstream dataplane scenarios.
+
+## 3. Detailed Breakdown of Sub-Testcases
+### `test_populate_fdb`
+- **Intent and logic:** Invokes the `populate_fdb` fixture (implicitly through its argument) to program MAC entries into the DUT. The test body is empty (`pass`), so all work happens in the fixture; successful completion confirms the fixture executed without error.
+- **Relevance:** Ensures prerequisite FDB entries exist, a foundational step before running traffic or control-plane tests that assume populated Layer-2 tables. Any failure highlights setup issues impacting broader suites relying on a primed FDB.
+- **Helper fixtures:**
+  - `populate_fdb`: Executes the actual Ansible/CLI calls to create the FDB entries. Without it the test would do nothing.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:**
+  - `populate_fdb` (required to populate the FDB).
+  - `copy_ptftests_directory` imported fixture ensures PTF side test files are available when invoked (even though not referenced directly in this file, the import triggers fixture autouse behavior if defined that way).
+- **Topology constraints:** Must execute on environments tagged as `t0`, `m0`, or `mx`.
+
+## 5. Key Inputs and Parameters
+- **Topology specification:** Provided via `pytest.mark.topology`; controls which inventory setups may run the test.
+- **Fixture-managed parameters:** `populate_fdb` likely consumes testbed definitions (e.g., interfaces, VLAN mappings, MAC addresses) from `testbed.yaml` or inventory group variables; specifics are not exposed in this file. **Not specified** explicitly in the test code.
+
+## 6. External Libraries and Modules
+- `pytest`: Supplies the testing framework, marker support, and fixture injection.
+- `tests.common.fixtures.ptfhost_utils.copy_ptftests_directory`: Fixture that prepares PTF assets required for dataplane validation steps.
+
+## 7. Unspecified Items
+- Detailed behavior of `populate_fdb`, exact MAC/VLAN values, and downstream validation steps are **Not specified** in this test file.


### PR DESCRIPTION
## Summary
- add analyzer documentation for the populate FDB testbed setup case

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df9e4b456c832f8eb7be110adc6745