### PR TITLE
Add VLAN test analyzer documentation

### DIFF
--- a/docs/t0_topology_testplan/vlan/test_vlan_analyzer.md
+++ b/docs/t0_topology_testplan/vlan/test_vlan_analyzer.md
@@ -1,0 +1,72 @@
+# VLAN Test Plan Analysis for `tests/vlan/test_vlan.py`
+
+## 1. Topology Type
+- **Identified Topology:** `t0` leaf-spine topology.
+- **Evidence:** The module-level `pytestmark` applies `pytest.mark.topology('t0')`, forcing PyTest to select T0 testbeds. Several fixtures (`rand_selected_dut`, `ports_list`, `vlan_intfs_dict`) and helper utilities (`running_vlan_ports_list`) are also part of the standard T0 fixture suite, reinforcing that the tests target a single ToR device in a T0 pod. Dual ToR setups are explicitly skipped via `if "dualtor" in tbinfo["topo"]["name"]`, which further narrows the expected environment to classic T0 rather than multi-ToR variants.
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate end-to-end VLAN forwarding behavior—broadcast flooding, unicast switching, VLAN tagging/untagging, and QinQ handling—on a SONiC DUT in a T0 topology.
+- **Broader Context:** Within the SONiC regression suite, this test module ensures that VLAN membership information, PVID assignments, and port-channel participation drive the expected packet tagging/forwarding behaviors. These checks confirm that the L2 forwarding plane honors VLAN configuration, enabling upper-layer features (L3 routing, routing protocols, QoS) to operate on a stable foundation.
+
+## 3. Detailed Breakdown of Sub-Testcases
+- **Helper Fixtures & Functions**
+  - `populate_mac_table`: Autouse fixture that restarts the `arp_update` daemon to refresh the MAC table, preventing flooding during tests.
+  - `ignore_expected_loganalyzer_exceptions`: Autouse fixture that configures Loganalyzer to ignore known benign errors (`Failed to get port by bridge port ID`).
+  - `build_icmp_packet` / `build_qinq_packet`: Craft baseline ICMP and QinQ packets with configurable VLAN IDs for reuse across tests.
+  - `verify_packets_with_portchannel`, `verify_icmp_packets`, `verify_unicast_packets`: Utility routines that abstract packet transmission and verification against single ports and port-channel members.
+  - Collectively, these helpers reduce duplication and encapsulate the validation logic required by each test case.
+
+- **`test_vlan_tc1_send_untagged`**
+  - **Intent:** Send untagged broadcasts from each VLAN member. Confirm that ports sharing the ingress PVID forward packets without tags, while VLAN members with different PVIDs forward tagged copies. No flooding occurs when the ingress has PVID 0.
+  - **Why It Matters:** Validates default VLAN egress tagging rules and ensures access ports/port-channels respect PVID configuration.
+
+- **`test_vlan_tc2_send_tagged`**
+  - **Intent:** For every permitted VLAN on each port, transmit a tagged ICMP packet and ensure egress logic mirrors the expectations: ports with matching PVID strip tags, others retain them.
+  - **Why It Matters:** Demonstrates correct handling of tagged ingress traffic, verifying that trunk memberships (`permit_vlanid`) drive forwarding decisions.
+
+- **`test_vlan_tc3_send_invalid_vid`**
+  - **Intent:** Inject packets with VLAN ID 4095 (reserved/invalid). Ensure no DUT port accepts or forwards these frames.
+  - **Why It Matters:** Confirms the switch drops frames with invalid VLAN IDs, avoiding accidental leakage into the network.
+
+- **`test_vlan_tc4_tagged_unicast`**
+  - **Intent:** Pick two tagged members of each VLAN (excluding PVID ports). Send directed ICMP traffic both ways and verify receipt.
+  - **Why It Matters:** Ensures unicast switching works for trunk members, proving MAC learning and VLAN membership interact correctly.
+
+- **`test_vlan_tc5_untagged_unicast`**
+  - **Intent:** Select two access ports (PVID equal to VLAN). Validate bidirectional untagged communication.
+  - **Why It Matters:** Confirms access VLAN members can exchange traffic without tags, a fundamental L2 behavior.
+
+- **`test_vlan_tc6_tagged_untagged_unicast`**
+  - **Intent:** Pair an access port with a trunk port in the same VLAN. Verify that the DUT tags frames headed to the trunk port and strips tags to the access port in both directions.
+  - **Why It Matters:** Demonstrates interoperability between access and trunk members and verifies dynamic tag insertion/removal on mixed VLAN segments.
+
+- **`test_vlan_tc7_tagged_qinq_switch_on_outer_tag`**
+  - **Intent:** Send QinQ frames between two tagged ports in the same VLAN. Ensure the DUT switches based on the outer tag while preserving inner encapsulation.
+  - **Why It Matters:** Validates QinQ handling on VLAN trunks, proving compatibility with double-tagged customer traffic scenarios.
+
+## 4. Dependencies and Prerequisites
+- **Fixtures:** `ptfadapter`, `duthosts`, `rand_one_dut_hostname`, `rand_selected_dut`, `tbinfo`, `ports_list`, `vlan_intfs_dict`, `loganalyzer`, `duthost`, `toggle_all_simulator_ports_to_rand_selected_tor_m` (DualToR mux control), `has_portchannels` helper. Autouse fixtures prepare MAC tables and logging filters.
+- **Topology Constraints:** Requires a T0 testbed with functional port-channels; several tests skip if port-channels are absent or if the topology is Dual ToR.
+- **Why They Matter:** These fixtures provide dynamic DUT/PTF selection, port/VLAN inventories, traffic injection capabilities, and environment controls needed to craft accurate packet expectations.
+
+## 5. Key Inputs and Parameters
+- **`tbinfo`**: Supplies topology metadata (e.g., `tbinfo["topo"]["name"]`) to gate tests on supported layouts.
+- **`ports_list` / `running_vlan_ports_list`**: Enumerate active VLAN member ports, their indices, and tagging state, driving per-port verification loops.
+- **`vlan_intfs_dict`**: Maps VLAN IDs to interface lists, enabling tagged/untagged pairing logic in unicast tests.
+- **`permit_vlanid` / `pvid` fields**: Extracted from `vlan_ports_list`, determine expected tagging treatment per egress port.
+- **`ptfadapter.dataplane` MAC lookups**: Provide accurate source/destination MACs for directed unicast packets.
+- **Reserved VLAN ID 4095**: Used as invalid VID for negative testing.
+
+## 6. External Libraries and Modules
+- **PyTest (`pytest`)**: Test framework for parametrization, fixtures, and marks.
+- **PTF (`ptf.packet`, `ptf.testutils`, `Mask`)**: Packet crafting and verification utilities for generating and matching Ethernet/ICMP/QinQ frames.
+- **`logging`**: Produces structured runtime logs.
+- **SONiC Test Helpers:**
+  - `tests.common.dualtor.mux_simulator_control` for mux state management.
+  - `tests.common.fixtures.duthost_utils` (e.g., `utils_vlan_intfs_dict_orig`, `ports_list`) to configure DUT fixture data.
+  - `tests.common.helpers.portchannel_to_vlan` utilities (`setup_po2vlan`, `running_vlan_ports_list`, etc.) to manipulate and query VLAN/port-channel state.
+- **Role:** These modules furnish the necessary primitives to configure DUT state, manage topology-specific behaviors, build traffic, and assert forwarding results.
+
+## 7. Unspecified Items
+- **Testbed File References:** Not specified in this test file.
+- **CLI Parameters / External Config:** Not specified beyond fixture-provided inputs.


### PR DESCRIPTION
## Summary
- document the VLAN test suite covering tagging, untagging, and QinQ behaviors
- capture fixtures, dependencies, and topology assumptions for tests/vlan/test_vlan.py

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df9fa39bec832f9f2f6baf893bb215