### PR TITLE
Add QA analyzer documentation for VLAN ping test

### DIFF
--- a/docs/t0_topology_testplan/vlan/test_vlan_ping_analyzer.md
+++ b/docs/t0_topology_testplan/vlan/test_vlan_ping_analyzer.md
@@ -1,0 +1,56 @@
+# VLAN Ping Test Analyzer
+
+## 1. Topology Type
+- **Identified Topologies:** The module-level `pytestmark` flags the test for execution on `t0`, `t0-52`, `m0`, `mx`, and `t0-2vlans` topologies.
+- **Inference Method:** The `pytest.mark.topology(...)` declaration in `tests/vlan/test_vlan_ping.py` directly enumerates the supported testbeds, indicating that the case targets leaf/spine T0-style fabrics (including dual ToR variants such as `mx` and multi-VLAN `t0-2vlans`). Additional logic in the `vlan_ping_setup` fixture inspects `tbinfo["topo"]` to adjust neighbor selection for `m0`, `mx`, and `dualtor-aa` deployments, confirming that the scenario assumes a T0/dual-ToR VLAN switching topology.
+
+## 2. Overall Test Case Purpose
+- **High-Level Goal:** Validate bidirectional L3 connectivity for statically programmed IPv4 and IPv6 neighbor entries on VLAN interfaces.
+- **Context in SONiC QA:** Within SONiC's VLAN and L3 forwarding validation, this test ensures that when static ARP/ND entries are injected for PTF-host-facing ports, the DUT can both reach the hosts and respond correctly after neighbor table manipulations (flush/add operations). This covers resilience of static neighbor handling across VLAN members and dual ToR scenarios.
+
+## 3. Detailed Breakdown of Sub-Testcases and Helpers
+- **`static_neighbor_entry` (helper):**
+  - Adds or removes static IPv4/IPv6 neighbor records on the DUT by issuing `arp` and `ip -6 neigh` commands based on the provided `oper` and `ip_version` arguments.
+  - Ensures the test can deterministically control neighbor table entries, which is crucial for validating static neighbor reachability.
+- **`vlan_ping_setup` (module fixture):**
+  - Gathers topology facts (`tbinfo`, `duthosts`, `nbrhosts`) to select an appropriate neighbor VM and two PTF ports within the same VLAN.
+  - Extracts MAC/IP addressing for the VM and PTF interfaces, computes VLAN network ranges, and yields dictionaries describing source/destination endpoints.
+  - Handles dual ToR adjustments (e.g., `dualtor-aa` lower ToR selection, port-channel mapping) and cleans up static neighbors on teardown.
+  - Provides the structured test inputs consumed by `test_vlan_ping`.
+- **`verify_icmp_packet` (helper):**
+  - Crafts ICMP echo packets with `ptf.testutils.simple_icmp_packet`, sending traffic from source to destination ports on the PTF adapter.
+  - Verifies the expected packet egress, adjusting for dual ToR upstream/downstream expectations (MAC address masking, VLAN interface MAC usage).
+  - Retries up to five times to accommodate transient forwarding convergence.
+- **`test_vlan_ping` (primary test):**
+  - Retrieves the chosen DUT (`rand_one_dut_hostname`) and the setup data from `vlan_ping_setup`.
+  - Optionally fetches VLAN interface MACs and flushes existing neighbor entries for dual ToR deployments to avoid known issues.
+  - Invokes `static_neighbor_entry(..., "add")` to install IPv4/IPv6 static neighbors for the selected PTF ports.
+  - Validates bidirectional connectivity between the DUT and each PTF host via `verify_icmp_packet`, covering both uplink (DUT→PTF) and downlink (PTF→DUT) directions.
+  - Exercises neighbor table resilience by selectively deleting and re-adding IPv6 entries and the IPv4 entries per host, then re-running connectivity checks.
+  - Confirms that static neighbor entries remain functional after flush/reconfigure cycles, fulfilling the overall validation objective.
+
+## 4. Dependencies and Prerequisites
+- **PyTest Fixtures:** `duthosts`, `rand_one_dut_hostname`, `ptfadapter`, `ptfhost`, `nbrhosts`, `tbinfo`, `lower_tor_host`, `toggle_all_simulator_ports_to_rand_selected_tor_m`, and `populate_mac_table` are required to supply DUT handles, topology metadata, PTF interfaces, and dual ToR simulator coordination.
+- **Topology Constraints:** Requires a T0-like topology with at least one VLAN containing two or more member interfaces mapped to PTF ports; dual ToR environments must have mux simulator control available.
+- **Host Capabilities:** The DUT must permit execution of privileged shell commands (`arp`, `ip neigh`) and expose minigraph/config facts. PTF hosts need `ifconfig` and `ip` utilities to report interface details.
+
+## 5. Key Inputs and Parameters
+- **`tbinfo` and `duthost` facts:** Determine topology type, VLAN membership, PTF port indices, and VLAN interface addressing.
+- **`nbrhosts` data:** Supplies VM neighbor configuration (MAC/IP) for selecting the uplink-facing host.
+- **`rand_one_dut_hostname` / `duthosts`:** Selects the DUT under test in multi-DUT environments.
+- **`ptfhost_info` & `vm_host_info` (from fixture):** Contain per-endpoint MAC/IP/VLAN metadata used for packet generation and neighbor programming.
+- **`toggle_all_simulator_ports_to_rand_selected_tor_m`:** Ensures mux ports in dual ToR topologies point toward the selected DUT before testing.
+
+## 6. External Libraries and Modules
+- **Standard Libraries:** `random`, `ipaddress`, `logging`, `six` for random selection, IP manipulations, logging, and text handling.
+- **PyTest:** Provides test/fixture scaffolding (`pytest`, fixtures).
+- **PTF Utilities:** `ptf.testutils` for packet crafting/sending/verifying, `ptf.packet` (Scapy wrapper) for packet manipulation, and `ptf.mask.Mask` to mask fields during verification.
+- **SONiC Test Helpers:**
+  - `tests.common.helpers.assertions.pytest_assert` for assertion handling with custom messages.
+  - `tests.common.dualtor.mux_simulator_control.toggle_all_simulator_ports_to_rand_selected_tor_m` fixture to steer muxes.
+  - `tests.common.dualtor.dual_tor_utils.lower_tor_host` fixture to identify the lower ToR.
+  - `tests.vlan.test_vlan.populate_mac_table` fixture for pre-populating DUT MAC tables when needed.
+
+## 7. Unspecified Items
+- Specific testbed inventory entries (e.g., exact interface names, IP subnets) – **Not specified.**
+- Explicit success criteria thresholds beyond ICMP reachability – **Not specified.**


### PR DESCRIPTION
## Summary
- document the VLAN static neighbor ping regression in a new analyzer markdown file
- cover topology scope, dependencies, helper roles, and unspecified elements for quick QA reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9fbcd4f0832fabc404d34a884f1c