### PR TITLE
Handle updated system health and logging CLI

### DIFF
--- a/spytest/apis/system/basic.py
+++ b/spytest/apis/system/basic.py
@@ -20,6 +20,163 @@ from utilities.common import delete_file, make_list
 import utilities.utils as utils_obj
 
 
+SYSTEM_STATUS_INVALID_PATTERNS = [
+    "Too many matches",
+    "No such command",
+    "Unknown command",
+    "Invalid input detected",
+    "Usage: show [OPTIONS] COMMAND",
+    "Error: Got unexpected extra argument",
+]
+
+HEALTH_OK_STATES = {
+    "ok",
+    "ready",
+    "system is ready",
+    "running",
+    "up",
+    "active",
+    "green",
+}
+
+HEALTH_BAD_STATES = {
+    "not ok",
+    "not ready",
+    "system is not ready",
+    "degraded",
+    "critical",
+    "down",
+    "failed",
+    "failure",
+    "inactive",
+    "unhealthy",
+    "waiting",
+    "red",
+    "disabled",
+}
+
+
+def _is_invalid_system_status_output(output):
+    if output is None:
+        return True
+    if isinstance(output, list):
+        output = "\n".join(str(entry) for entry in output)
+    for pattern in SYSTEM_STATUS_INVALID_PATTERNS:
+        if pattern in output:
+            return True
+    return False
+
+
+def _normalize_health_state(value):
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    normalized = normalized.split("(")[0].strip()
+    normalized = normalized.split("-")[0].strip() if normalized.startswith("system is") else normalized
+    if normalized in HEALTH_OK_STATES:
+        return True
+    if normalized in HEALTH_BAD_STATES:
+        return False
+    if normalized.startswith("system is ready"):
+        return True
+    if normalized.startswith("system is not ready"):
+        return False
+    return None
+
+
+def _parse_system_health_summary(output):
+    if not output:
+        return None, {}
+    if isinstance(output, list):
+        output = "\n".join(str(entry) for entry in output)
+    overall = None
+    services = {}
+    service_indent = None
+    for raw_line in output.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            if service_indent is not None:
+                service_indent = None
+            continue
+        lower = stripped.lower()
+        if lower.startswith("overall system state"):
+            overall = stripped.split(":", 1)[1].strip() if ":" in stripped else stripped
+            continue
+        if lower.startswith("system status") and ":" in stripped and overall is None:
+            overall = stripped.split(":", 1)[1].strip()
+            continue
+        if lower.startswith("services"):
+            service_indent = len(raw_line) - len(raw_line.lstrip())
+            continue
+        if service_indent is not None:
+            current_indent = len(raw_line) - len(raw_line.lstrip())
+            if current_indent <= service_indent and ":" not in stripped:
+                service_indent = None
+                continue
+            entry = stripped.lstrip("- ")
+            if ":" in entry:
+                name, state = entry.split(":", 1)
+                services[name.strip().lower()] = state.strip()
+                continue
+            service_indent = None
+    return overall, services
+
+
+def _prepare_show_kwargs(kwargs):
+    cmd_kwargs = kwargs.copy()
+    cmd_kwargs.pop("type", None)
+    cmd_kwargs.setdefault("skip_error_check", True)
+    cmd_kwargs.setdefault("skip_tmpl", True)
+    return cmd_kwargs
+
+
+def _collect_system_health_summary(dut, cli_type="click", **kwargs):
+    commands = []
+    if cli_type == "click":
+        commands.extend(["sudo show system-health summary", "show system-health summary"])
+    else:
+        commands.append("show system-health summary")
+    cmd_kwargs = _prepare_show_kwargs(kwargs)
+    for command in commands:
+        output = st.show(dut, command, type=cli_type, **cmd_kwargs)
+        if _is_invalid_system_status_output(output):
+            continue
+        overall, services = _parse_system_health_summary(output)
+        if overall or services:
+            return overall, services
+    return None, {}
+
+
+def _lookup_service_status(services, service):
+    if not service or not services:
+        return None
+    service_keys = {
+        service.lower(),
+        service.replace("_", " ").lower(),
+        service.replace("_", "-").lower(),
+        service.replace("-", " ").lower(),
+    }
+    for name, state in services.items():
+        normalized_name = name.lower()
+        if normalized_name in service_keys:
+            return state
+    return None
+
+
+def _evaluate_system_health(overall, services, service=None):
+    if service:
+        state = _lookup_service_status(services, service)
+        normalized_state = _normalize_health_state(state)
+        if normalized_state is not None:
+            return normalized_state
+    normalized_overall = _normalize_health_state(overall)
+    if normalized_overall is not None:
+        return normalized_overall
+    return None
+
+
 def force_cli_type_to_klish(cli_type):
     cli_type = "klish" if cli_type in utils_obj.get_supported_ui_type_list() else cli_type
     return cli_type
@@ -49,45 +206,58 @@ def get_system_status(dut, service=None, **kwargs):
     if cli_type != 'click':
         cli_type = utils_obj.override_supported_ui("rest-put", "rest-patch", cli_type=cli_type)
     kwargs.setdefault("skip_tmpl", True)
-    output = "???"
     if 'cmd' in kwargs:
         if cli_type == 'click':
             return st.show(dut, kwargs['cmd'], skip_tmpl=True, skip_error_check=True, type=cli_type)
         if cli_type == 'klish':
             return st.show(dut, kwargs['cmd'], skip_tmpl=True, skip_error_check=True, type=cli_type)
     try:
+        output = None
+        output_valid = False
+        cmd_kwargs = _prepare_show_kwargs(kwargs)
         has_status_core = st.is_feature_supported("system-status-core", dut)
         if has_status_core:
             if cli_type == 'klish':
-                if 'skip_error_check' not in kwargs:
-                    kwargs['skip_error_check'] = True
-                output = st.show(dut, "show system status core", type=cli_type, **kwargs)
-                if 'Error: Invalid input detected at' in output:
+                output = st.show(dut, "show system status core", type=cli_type, **cmd_kwargs)
+                if _is_invalid_system_status_output(output):
                     st.log('show system status core is not supported in klish. Trying with click')
                     cli_type = 'click'
+                    output = None
             if cli_type == 'click':
-                output = st.show(dut, "show system status core", type=cli_type, **kwargs)
-            if "Error: Got unexpected extra argument (core)" in output:
+                output = st.show(dut, "show system status core", type=cli_type, **cmd_kwargs)
+            if _is_invalid_system_status_output(output):
                 has_status_core = False
+            else:
+                output_valid = True
         if not has_status_core:
             if cli_type == 'klish':
-                if 'skip_error_check' not in kwargs:
-                    kwargs['skip_error_check'] = True
-                output = st.show(dut, "show system status", type=cli_type, **kwargs)
-                if 'Error: Invalid input detected at' in output:
+                output = st.show(dut, "show system status", type=cli_type, **cmd_kwargs)
+                if _is_invalid_system_status_output(output):
                     st.log('show system status is not supported in klish. Trying with click')
                     cli_type = 'click'
+                    output = None
             if cli_type == 'click':
-                output = st.show(dut, "show system status", type=cli_type, **kwargs)
-            if "Error: Got unexpected extra argument (status)" in output:
-                return None
+                output = st.show(dut, "show system status", type=cli_type, **cmd_kwargs)
+            if _is_invalid_system_status_output(output):
+                output_valid = False
+            else:
+                output_valid = True
+        if not output_valid:
+            overall, services = _collect_system_health_summary(dut, cli_type='click', **kwargs)
+            evaluation = _evaluate_system_health(overall, services, service=service)
+            if evaluation is not None:
+                return evaluation
+            return False
         retval = st.parse_show(dut, "show system status", output)
         if not retval:
             return False
-        if retval[0]["status"] == "ready":
+        status_value = str(retval[0].get("status", "")).lower()
+        if status_value == "ready":
             return True
-        if service and retval[0][service] == "Up":
-            return True
+        if service:
+            service_status = str(retval[0].get(service, "")).lower()
+            if service_status in ["up", "ok", "ready"]:
+                return True
     except Exception as exp:
         msg = "Failed to read system online status output='{}' error='{}'"
         st.warn(msg.format(output, exp))
@@ -98,11 +268,23 @@ def get_system_status_all(dut, service=None, **kwargs):
     cli_type = st.get_ui_type(dut, **kwargs)
     cli_type = 'klish' if cli_type in utils_obj.get_supported_ui_type_list() + ['rest-patch', 'rest-put'] else cli_type
     failed_services = []
+    cmd_kwargs = _prepare_show_kwargs(kwargs)
     if cli_type == 'click':
         cmd = "sudo show system status"
     if cli_type == 'klish':
         cmd = "show system status"
-    output = st.show(dut, cmd, type=cli_type, **kwargs)
+    output = st.show(dut, cmd, type=cli_type, **cmd_kwargs)
+    if _is_invalid_system_status_output(output):
+        overall, services = _collect_system_health_summary(dut, cli_type='click', **kwargs)
+        evaluation = _evaluate_system_health(overall, services, service=service)
+        if evaluation:
+            return True
+        for name, state in services.items():
+            if _normalize_health_state(state) is False:
+                failed_services.append("'{}' service state '{}'".format(name, state))
+        if failed_services:
+            st.log("Failed services list : {}".format(failed_services))
+        return False
     if not output:
         return False
     if output[0]["status"] == "ready":
@@ -118,11 +300,18 @@ def get_system_status_all(dut, service=None, **kwargs):
 def get_system_status_all_brief(dut, service=None, **kwargs):
     cli_type = st.get_ui_type(dut, **kwargs)
     cli_type = 'klish' if cli_type in utils_obj.get_supported_ui_type_list() + ['rest-patch', 'rest-put'] else cli_type
+    cmd_kwargs = _prepare_show_kwargs(kwargs)
     if cli_type == 'click':
         cmd = "sudo show system status brief"
     if cli_type == 'klish':
         cmd = "show system status brief"
-    output = st.show(dut, cmd, type=cli_type, **kwargs)
+    output = st.show(dut, cmd, type=cli_type, **cmd_kwargs)
+    if _is_invalid_system_status_output(output):
+        overall, services = _collect_system_health_summary(dut, cli_type='click', **kwargs)
+        evaluation = _evaluate_system_health(overall, services, service=service)
+        if evaluation is None:
+            return False
+        return evaluation
     if not output:
         return False
     if output[0]["status"] == "System is ready":
@@ -136,12 +325,24 @@ def get_system_status_all_detail(dut, service=None, **kwargs):
     cli_type = st.get_ui_type(dut, **kwargs)
     failed_services = []
     cli_type = 'klish' if cli_type in utils_obj.get_supported_ui_type_list() + ['rest-patch', 'rest-put'] else cli_type
+    cmd_kwargs = _prepare_show_kwargs(kwargs)
     if cli_type == 'click':
-        output = st.show(dut, "sudo show system status detail", type=cli_type, **kwargs)
+        output = st.show(dut, "sudo show system status detail", type=cli_type, **cmd_kwargs)
     if cli_type == 'klish':
-        output = st.show(dut, "show system status detail", type=cli_type, **kwargs)
+        output = st.show(dut, "show system status detail", type=cli_type, **cmd_kwargs)
     if 'output' in kwargs:
         return output
+    if _is_invalid_system_status_output(output):
+        overall, services = _collect_system_health_summary(dut, cli_type='click', **kwargs)
+        evaluation = _evaluate_system_health(overall, services, service=service)
+        if evaluation:
+            return True
+        for name, state in services.items():
+            if _normalize_health_state(state) is False:
+                failed_services.append("'{}' service state '{}'".format(name, state))
+        if failed_services:
+            st.log("Failed services list : {}".format(failed_services))
+        return False
     if not output:
         return False
     if output[0]["status"] == "System is ready":

--- a/spytest/apis/system/logging.py
+++ b/spytest/apis/system/logging.py
@@ -260,8 +260,37 @@ def get_syslog_from_remote_server(dut, severity=None, filter_list=None, lines=No
 
 
 def sonic_clear(dut, skip_error_check=True, **kwargs):
-    if st.is_feature_supported("sonic-clear-logging-command", dut):
-        st.config(dut, "sonic-clear logging", skip_error_check=skip_error_check, **kwargs)
+    if not st.is_feature_supported("sonic-clear-logging-command", dut):
+        return
+
+    def _is_invalid_output(output):
+        if output is None:
+            return True
+        text = str(output).strip()
+        if not text:
+            return False
+        invalid_tokens = [
+            "No such command",
+            "Unknown command",
+            "Usage: sonic-clear",
+        ]
+        return any(token in text for token in invalid_tokens)
+
+    commands = [
+        "sonic-clear logging",
+        "sonic-clear log",
+        "sonic-clear logs",
+    ]
+
+    for command in commands:
+        output = st.config(dut, command, skip_error_check=True, **kwargs)
+        if _is_invalid_output(output):
+            st.debug("sonic-clear logging command '{}' not supported, trying alternative syntax".format(command))
+            continue
+        return output
+
+    if not skip_error_check:
+        st.config(dut, commands[0], skip_error_check=skip_error_check, **kwargs)
 
 
 def check_for_logs_after_reboot(dut, severity=None, log_severity=[], except_logs=[]):


### PR DESCRIPTION
## Summary
- detect unsupported `show system status` variants and fall back to the new `show system-health summary` output when checking device readiness
- normalize system health status parsing so brief/all/detail helpers continue to work after the CLI renaming
- try alternate `sonic-clear` logging subcommands to support the refreshed command set

## Testing
- python -m compileall spytest/apis/system/basic.py spytest/apis/system/logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e61c4ab5a48328969fb78315f9a4d3